### PR TITLE
fix: prevent tab bar shift on workspace deactivation

### DIFF
--- a/AirlockApp/Sources/AirlockApp/ContentView.swift
+++ b/AirlockApp/Sources/AirlockApp/ContentView.swift
@@ -65,6 +65,7 @@ struct ContentView: View {
     @ViewBuilder
     private func tabContent(workspace: Workspace) -> some View {
         ZStack {
+            Color.clear
             // Terminal stays alive across tab switches
             Group {
                 if appState.isActive(workspace) {


### PR DESCRIPTION
## Summary

- Fixes tab bar position shifting downward after deactivating a workspace
- Root cause: the `ZStack` in `tabContent` had no greedy-fill child, so when `TerminalSplitView` was swapped for `ContentUnavailableView` (which has intrinsic sizing), the ZStack shrank and the parent VStack was repositioned within the NavigationSplitView detail area
- Fix: add `Color.clear` as the first ZStack child to force it to always fill available space

## Test plan

- [ ] Activate a workspace, verify tab bar position
- [ ] Deactivate the workspace, verify tab bar stays in the same position
- [ ] Switch tabs while inactive, verify no layout shift
- [ ] Reactivate, verify normal layout

Closes #7

Generated with [Claude Code](https://claude.com/claude-code)