### PR TITLE
fix: set UTF-8 locale in container for CJK input support

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:22-bookworm-slim
 
+ENV LANG=C.UTF-8
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     curl \

--- a/container/entrypoint-keepalive.sh
+++ b/container/entrypoint-keepalive.sh
@@ -23,6 +23,8 @@ fi
 # Write environment setup to .bashrc so docker exec sessions inherit env vars.
 # PID 1 env is NOT inherited by docker exec, so this is required.
 cat > /home/airlock/.airlock-env.sh << 'ENVEOF'
+export LANG=C.UTF-8
+
 if [ -f /run/airlock/env.enc ]; then
     set -a
     source /run/airlock/env.enc

--- a/internal/container/manager.go
+++ b/internal/container/manager.go
@@ -117,6 +117,7 @@ func BuildClaudeConfig(opts RunOpts) ContainerConfig {
 			fmt.Sprintf("http_proxy=%s", proxyURL),
 			fmt.Sprintf("https_proxy=%s", proxyURL),
 			"NO_PROXY=localhost,127.0.0.1",
+			"LANG=C.UTF-8",
 		},
 		CapDrop: []string{"ALL"},
 		Cmd:     []string{"claude", "--dangerouslySkipPermissions"},

--- a/internal/container/manager_test.go
+++ b/internal/container/manager_test.go
@@ -437,6 +437,27 @@ func TestBuildProxyConfigNoMappingPath(t *testing.T) {
 	}
 }
 
+func TestBuildClaudeConfigLocaleEnv(t *testing.T) {
+	opts := container.RunOpts{
+		Workspace:   "/tmp/ws",
+		Image:       "airlock-claude:latest",
+		NetworkName: "airlock-net",
+		ClaudeDir:   "/home/user/.claude",
+		ProxyPort:   8080,
+	}
+	cfg := container.BuildClaudeConfig(opts)
+	found := false
+	for _, env := range cfg.Env {
+		if env == "LANG=C.UTF-8" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected LANG=C.UTF-8 in Env, got: %v", cfg.Env)
+	}
+}
+
 func TestBuildProxyConfigMappingEnv(t *testing.T) {
 	opts := container.RunOpts{
 		ProxyImage:       "airlock-proxy:latest",


### PR DESCRIPTION
## Summary
- Set `LANG=C.UTF-8` in Dockerfile, `BuildClaudeConfig()` env vars, and `.airlock-env.sh` for docker exec sessions
- Added test verifying locale env var is present in container config
- No additional packages needed -- `C.UTF-8` is built into glibc on Debian bookworm

## Test plan
- [x] `make test` passes with new locale env test
- [ ] Manual: `docker exec` into container, run `locale` to verify `LANG=C.UTF-8`
- [ ] Manual: Type Korean characters in container terminal

Closes #3