### PR TITLE
fix: preserve terminal sessions across split direction changes

### DIFF
--- a/AirlockApp/Sources/AirlockApp/Views/Terminal/NSSplitViewRepresentable.swift
+++ b/AirlockApp/Sources/AirlockApp/Views/Terminal/NSSplitViewRepresentable.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+import SwiftTerm
+
+struct NSSplitViewRepresentable: NSViewRepresentable {
+    let paneIDs: [UUID]
+    let isVertical: Bool
+    let containerName: String
+    let onPaneTerminated: (UUID) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(containerName: containerName, onPaneTerminated: onPaneTerminated)
+    }
+
+    func makeNSView(context: Context) -> NSSplitView {
+        let splitView = NSSplitView()
+        splitView.isVertical = isVertical
+        splitView.dividerStyle = .thin
+        splitView.delegate = context.coordinator
+
+        for paneID in paneIDs {
+            let terminal = context.coordinator.createTerminal(for: paneID)
+            splitView.addArrangedSubview(terminal)
+            context.coordinator.startTerminal(terminal)
+        }
+        context.coordinator.currentPaneIDs = paneIDs
+
+        DispatchQueue.main.async {
+            context.coordinator.equalizePanes(in: splitView)
+        }
+
+        return splitView
+    }
+
+    func updateNSView(_ splitView: NSSplitView, context: Context) {
+        let coord = context.coordinator
+        coord.onPaneTerminated = onPaneTerminated
+
+        // Toggle direction without destroying subviews (#5)
+        if splitView.isVertical != isVertical {
+            splitView.isVertical = isVertical
+        }
+
+        let oldIDs = coord.currentPaneIDs
+        let newIDs = paneIDs
+
+        if oldIDs != newIDs {
+            // Remove panes that no longer exist
+            let removed = oldIDs.filter { !newIDs.contains($0) }
+            for id in removed {
+                coord.removeTerminal(for: id, from: splitView)
+            }
+
+            // Add new panes
+            let added = newIDs.filter { !oldIDs.contains($0) }
+            for id in added {
+                let terminal = coord.createTerminal(for: id)
+                splitView.addArrangedSubview(terminal)
+                coord.startTerminal(terminal)
+            }
+
+            coord.currentPaneIDs = newIDs
+
+            // Equalize panes after add/remove (#4)
+            DispatchQueue.main.async {
+                coord.equalizePanes(in: splitView)
+            }
+        }
+    }
+
+    // MARK: - Coordinator
+
+    final class Coordinator: NSObject, NSSplitViewDelegate {
+        var terminals: [UUID: AirlockTerminalView] = [:]
+        var delegates: [UUID: PaneDelegate] = [:]
+        var currentPaneIDs: [UUID] = []
+        let containerName: String
+        var onPaneTerminated: (UUID) -> Void
+
+        init(containerName: String, onPaneTerminated: @escaping (UUID) -> Void) {
+            self.containerName = containerName
+            self.onPaneTerminated = onPaneTerminated
+        }
+
+        func createTerminal(for paneID: UUID) -> AirlockTerminalView {
+            let terminal = AirlockTerminalView(frame: .zero)
+            terminal.font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+
+            let paneDelegate = PaneDelegate(paneID: paneID) { [weak self] id in
+                self?.onPaneTerminated(id)
+            }
+            terminal.processDelegate = paneDelegate
+
+            terminals[paneID] = terminal
+            delegates[paneID] = paneDelegate
+            return terminal
+        }
+
+        func startTerminal(_ terminal: AirlockTerminalView) {
+            let escaped = AirlockTerminalView.shellEscape(containerName)
+            let cmd = "docker exec -it \(escaped) /bin/bash"
+            let env = CLIService.enrichedEnvironment().map { "\($0.key)=\($0.value)" }
+            terminal.startAfterLayout(cmd: cmd, env: env)
+        }
+
+        func removeTerminal(for paneID: UUID, from splitView: NSSplitView) {
+            if let terminal = terminals[paneID] {
+                terminal.removeFromSuperview()
+                terminals.removeValue(forKey: paneID)
+            }
+            delegates.removeValue(forKey: paneID)
+        }
+
+        func equalizePanes(in splitView: NSSplitView) {
+            let count = splitView.arrangedSubviews.count
+            guard count > 1 else { return }
+            let dividerThickness = splitView.dividerThickness
+            let totalDividers = CGFloat(count - 1) * dividerThickness
+            let totalSpace = (splitView.isVertical ? splitView.bounds.width : splitView.bounds.height) - totalDividers
+            guard totalSpace > 0 else { return }
+            let paneSize = totalSpace / CGFloat(count)
+
+            for i in 0..<(count - 1) {
+                let position = paneSize * CGFloat(i + 1) + dividerThickness * CGFloat(i)
+                splitView.setPosition(position, ofDividerAt: i)
+            }
+        }
+
+        // MARK: NSSplitViewDelegate
+
+        func splitView(_ splitView: NSSplitView, constrainMinCoordinate proposedMinimumPosition: CGFloat, ofSubviewAt dividerIndex: Int) -> CGFloat {
+            proposedMinimumPosition + 80
+        }
+
+        func splitView(_ splitView: NSSplitView, constrainMaxCoordinate proposedMaximumPosition: CGFloat, ofSubviewAt dividerIndex: Int) -> CGFloat {
+            proposedMaximumPosition - 80
+        }
+    }
+
+    // MARK: - PaneDelegate
+
+    final class PaneDelegate: NSObject, LocalProcessTerminalViewDelegate {
+        let paneID: UUID
+        let onTerminated: (UUID) -> Void
+
+        init(paneID: UUID, onTerminated: @escaping (UUID) -> Void) {
+            self.paneID = paneID
+            self.onTerminated = onTerminated
+        }
+
+        func sizeChanged(source: LocalProcessTerminalView, newCols: Int, newRows: Int) {}
+        func setTerminalTitle(source: LocalProcessTerminalView, title: String) {}
+        func hostCurrentDirectoryUpdate(source: SwiftTerm.TerminalView, directory: String?) {}
+
+        func processTerminated(source: SwiftTerm.TerminalView, exitCode: Int32?) {
+            Task { @MainActor in
+                onTerminated(paneID)
+            }
+        }
+    }
+}

--- a/AirlockApp/Sources/AirlockApp/Views/Terminal/TerminalSplitView.swift
+++ b/AirlockApp/Sources/AirlockApp/Views/Terminal/TerminalSplitView.swift
@@ -48,6 +48,30 @@ struct TerminalSplitView: View {
             }
             .disabled(panes.count < 2)
 
+            Divider().frame(height: 16)
+
+            ForEach(Array(panes.enumerated()), id: \.element.id) { index, pane in
+                HStack(spacing: 2) {
+                    Text("T\(index + 1)")
+                        .font(.caption)
+                        .fontDesign(.monospaced)
+                    if panes.count > 1 {
+                        Button {
+                            removePane(id: pane.id)
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, 4)
+                .padding(.vertical, 2)
+                .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+            }
+
             Spacer()
 
             Text("\(panes.count) terminal\(panes.count == 1 ? "" : "s")")
@@ -59,43 +83,15 @@ struct TerminalSplitView: View {
         .background(Color(nsColor: .controlBackgroundColor))
     }
 
-    @ViewBuilder
     private var terminalGrid: some View {
-        if splitVertical {
-            HSplitView {
-                ForEach(panes) { pane in
-                    singleTerminal(pane: pane)
-                }
+        NSSplitViewRepresentable(
+            paneIDs: panes.map(\.id),
+            isVertical: splitVertical,
+            containerName: containerName,
+            onPaneTerminated: { id in
+                removePane(id: id)
             }
-        } else {
-            VSplitView {
-                ForEach(panes) { pane in
-                    singleTerminal(pane: pane)
-                }
-            }
-        }
-    }
-
-    private func singleTerminal(pane: TerminalPane) -> some View {
-        VStack(spacing: 0) {
-            if panes.count > 1 {
-                HStack {
-                    Spacer()
-                    Button {
-                        removePane(pane)
-                    } label: {
-                        Image(systemName: "xmark")
-                            .font(.caption2)
-                    }
-                    .buttonStyle(.plain)
-                    .padding(2)
-                }
-                .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
-            }
-            TerminalView(containerName: containerName) {
-                removePane(pane)
-            }
-        }
+        )
     }
 
     private func handleAction(_ terminalAction: TerminalAction) {
@@ -116,8 +112,8 @@ struct TerminalSplitView: View {
         panes.append(TerminalPane())
     }
 
-    private func removePane(_ pane: TerminalPane) {
+    private func removePane(id: UUID) {
         guard panes.count > 1 else { return }
-        panes.removeAll { $0.id == pane.id }
+        panes.removeAll { $0.id == id }
     }
 }

--- a/AirlockApp/Sources/AirlockApp/Views/Terminal/TerminalView.swift
+++ b/AirlockApp/Sources/AirlockApp/Views/Terminal/TerminalView.swift
@@ -76,4 +76,8 @@ final class AirlockTerminalView: LocalProcessTerminalView {
             start()
         }
     }
+
+    static func shellEscape(_ str: String) -> String {
+        "'" + str.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
 }


### PR DESCRIPTION
## Summary
- Replace conditional `HSplitView`/`VSplitView` with custom `NSSplitViewRepresentable` wrapping `NSSplitView` directly
- Toggling `isVertical` preserves all subviews and running docker exec processes
- Pane ratios equalized automatically via `setPosition(_:ofDividerAt:)` on add/remove
- Added pane indicators with close buttons in toolbar
- Minimum pane size enforced at 80pt via `NSSplitViewDelegate`

## Test plan
- [ ] Manual: Split terminal, change direction (Cmd+D / Cmd+Shift+D), verify sessions survive
- [ ] Manual: Add panes (Cmd+T), verify equal sizing
- [ ] Manual: Close pane from toolbar indicator, verify remaining panes re-equalize
- [ ] `make gui-build` passes

Closes #5, Closes #4