### PR TITLE
feat: per-workspace MCP server allow-list

### DIFF
--- a/AirlockApp/Sources/AirlockApp/Models/AppState.swift
+++ b/AirlockApp/Sources/AirlockApp/Models/AppState.swift
@@ -181,6 +181,7 @@ struct AppSettings: Codable, Equatable {
     var containerImage: String = "airlock-claude:latest"
     var proxyImage: String = "airlock-proxy:latest"
     var passthroughHosts: [String] = ["api.anthropic.com", "auth.anthropic.com"]
+    var enabledMCPServers: [String]?
     var theme: AppTheme = .system
     var terminal: TerminalSettings = TerminalSettings()
 
@@ -192,6 +193,7 @@ struct AppSettings: Codable, Equatable {
         containerImage = try container.decodeIfPresent(String.self, forKey: .containerImage) ?? "airlock-claude:latest"
         proxyImage = try container.decodeIfPresent(String.self, forKey: .proxyImage) ?? "airlock-proxy:latest"
         passthroughHosts = try container.decodeIfPresent([String].self, forKey: .passthroughHosts) ?? ["api.anthropic.com", "auth.anthropic.com"]
+        enabledMCPServers = try container.decodeIfPresent([String].self, forKey: .enabledMCPServers)
         theme = try container.decodeIfPresent(AppTheme.self, forKey: .theme) ?? .system
         terminal = try container.decodeIfPresent(TerminalSettings.self, forKey: .terminal) ?? TerminalSettings()
     }
@@ -202,11 +204,13 @@ struct ResolvedSettings: Sendable {
     let proxyImage: String
     let passthroughHosts: [String]
     let proxyPort: Int
+    let enabledMCPServers: [String]?
 
     init(global: AppSettings, workspace: Workspace) {
         self.containerImage = workspace.containerImageOverride ?? global.containerImage
         self.proxyImage = workspace.proxyImageOverride ?? global.proxyImage
         self.passthroughHosts = workspace.passthroughHostsOverride ?? global.passthroughHosts
         self.proxyPort = workspace.proxyPortOverride ?? 8080
+        self.enabledMCPServers = workspace.enabledMCPServersOverride ?? global.enabledMCPServers
     }
 }

--- a/AirlockApp/Sources/AirlockApp/Models/Workspace.swift
+++ b/AirlockApp/Sources/AirlockApp/Models/Workspace.swift
@@ -9,6 +9,7 @@ struct Workspace: Identifiable, Codable, Hashable {
     var proxyImageOverride: String?
     var passthroughHostsOverride: [String]?
     var proxyPortOverride: Int?
+    var enabledMCPServersOverride: [String]?
 
     // Runtime state (not persisted)
     var isActive: Bool = false
@@ -20,6 +21,7 @@ struct Workspace: Identifiable, Codable, Hashable {
     enum CodingKeys: String, CodingKey {
         case id, name, path, envFilePath, containerImageOverride
         case proxyImageOverride, passthroughHostsOverride, proxyPortOverride
+        case enabledMCPServersOverride
     }
 
     init(from decoder: Decoder) throws {
@@ -32,6 +34,7 @@ struct Workspace: Identifiable, Codable, Hashable {
         proxyImageOverride = try container.decodeIfPresent(String.self, forKey: .proxyImageOverride)
         passthroughHostsOverride = try container.decodeIfPresent([String].self, forKey: .passthroughHostsOverride)
         proxyPortOverride = try container.decodeIfPresent(Int.self, forKey: .proxyPortOverride)
+        enabledMCPServersOverride = try container.decodeIfPresent([String].self, forKey: .enabledMCPServersOverride)
     }
 
     var shortID: String {

--- a/AirlockApp/Sources/AirlockApp/Services/ContainerSessionService.swift
+++ b/AirlockApp/Sources/AirlockApp/Services/ContainerSessionService.swift
@@ -28,6 +28,12 @@ final class ContainerSessionService {
         args += ["--proxy-port", String(resolved.proxyPort)]
         args += ["--container-image", resolved.containerImage]
         args += ["--proxy-image", resolved.proxyImage]
+        // Only pass --enabled-mcps when an explicit allow-list is set; nil
+        // means "no filtering" and we leave the flag off so the Go CLI keeps
+        // the existing behavior of forwarding all MCPs from settings.json.
+        if let mcpAllowlist = resolved.enabledMCPServers {
+            args += ["--enabled-mcps", mcpAllowlist.joined(separator: ",")]
+        }
         let result = try await cli.run(args: args, workingDirectory: workspace.path)
         if result.exitCode != 0 {
             throw NSError(

--- a/AirlockApp/Sources/AirlockApp/Services/MCPInventoryService.swift
+++ b/AirlockApp/Sources/AirlockApp/Services/MCPInventoryService.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Reads the user's Claude settings files to enumerate the MCP server names
+/// configured at the global level. The GUI uses this list to populate the
+/// per-workspace MCP allow-list picker.
+///
+/// Note: this reads from the host filesystem (`~/.claude/settings*.json`),
+/// not the Docker volume. The Docker volume is the authoritative source at
+/// runtime, but the host file is the editable copy users interact with via
+/// `claude mcp add` and reflects what will be mounted into the container at
+/// session start. MCPs added via `claude mcp add` from inside a running
+/// container only land in the volume; they will not appear in this picker
+/// until `airlock config export` syncs the volume back to the host.
+enum MCPInventoryService {
+    static func discoverServerNames(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> [String] {
+        let claudeDir = homeDirectory.appendingPathComponent(".claude")
+        let candidates = [
+            claudeDir.appendingPathComponent("settings.json"),
+            claudeDir.appendingPathComponent("settings.local.json"),
+        ]
+
+        var names = Set<String>()
+        for url in candidates {
+            guard let data = try? Data(contentsOf: url),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let mcpServers = json["mcpServers"] as? [String: Any] else {
+                continue
+            }
+            for name in mcpServers.keys {
+                names.insert(name)
+            }
+        }
+        return names.sorted()
+    }
+}

--- a/AirlockApp/Sources/AirlockApp/Views/Settings/MCPAllowListPicker.swift
+++ b/AirlockApp/Sources/AirlockApp/Views/Settings/MCPAllowListPicker.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+/// Reusable picker for the MCP server allow-list. Used in both global
+/// settings (`SettingsView`) and per-workspace overrides
+/// (`WorkspaceSettingsView`). The two call sites differ only in label
+/// strings, so the picker takes them as parameters and the surrounding
+/// `Section` stays at the call site. Parents that need to react to the
+/// enable toggle (e.g., to seed the selection set) attach `.onChange(of:)`
+/// to the same binding they pass in.
+struct MCPAllowListPicker: View {
+    @Binding var enabled: Bool
+    @Binding var selection: Set<String>
+    let discovered: [String]
+    let toggleLabel: String
+    let restrictedCaption: String
+    let unrestrictedCaption: String
+    let emptyInventoryCaption: String
+    let noneSelectedWarning: String
+
+    var body: some View {
+        Toggle(toggleLabel, isOn: $enabled)
+        if enabled {
+            if discovered.isEmpty {
+                Text(emptyInventoryCaption)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                Text(restrictedCaption)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                ForEach(discovered, id: \.self) { name in
+                    Toggle(name, isOn: Binding(
+                        get: { selection.contains(name) },
+                        set: { isOn in
+                            if isOn { selection.insert(name) }
+                            else { selection.remove(name) }
+                        }
+                    ))
+                    .toggleStyle(.checkbox)
+                }
+                if selection.isEmpty {
+                    Text(noneSelectedWarning)
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
+            }
+        } else {
+            Text(unrestrictedCaption)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/AirlockApp/Sources/AirlockApp/Views/Settings/SettingsView.swift
+++ b/AirlockApp/Sources/AirlockApp/Views/Settings/SettingsView.swift
@@ -11,6 +11,9 @@ struct GlobalSettingsSheet: View {
     @State private var showImportSheet = false
     @State private var showResetAlert = false
     @State private var showRemoveAnthropicConfirm = false
+    @State private var discoveredMCPServers: [String] = []
+    @State private var restrictMCPServers = false
+    @State private var enabledMCPSelection: Set<String> = []
 
     var body: some View {
         VStack(spacing: 0) {
@@ -84,6 +87,24 @@ struct GlobalSettingsSheet: View {
                         .padding(8)
                         .background(Color.yellow.opacity(0.08))
                         .clipShape(RoundedRectangle(cornerRadius: 4))
+                    }
+                }
+
+                Section("MCP Servers") {
+                    MCPAllowListPicker(
+                        enabled: $restrictMCPServers,
+                        selection: $enabledMCPSelection,
+                        discovered: discoveredMCPServers,
+                        toggleLabel: "Restrict available MCP servers",
+                        restrictedCaption: "Only the checked MCP servers will be active inside the container.",
+                        unrestrictedCaption: "All MCP servers from ~/.claude/settings.json will be available.",
+                        emptyInventoryCaption: "No MCP servers found in ~/.claude/settings.json. Use `claude mcp add` to install one.",
+                        noneSelectedWarning: "No MCP servers will be available — the container will see an empty mcpServers map."
+                    )
+                    .onChange(of: restrictMCPServers) { _, newValue in
+                        if !newValue {
+                            enabledMCPSelection = []
+                        }
                     }
                 }
 
@@ -170,6 +191,14 @@ struct GlobalSettingsSheet: View {
         let store = WorkspaceStore()
         settings = (try? store.loadSettings()) ?? AppSettings()
         passthroughText = settings.passthroughHosts.joined(separator: "\n")
+        discoveredMCPServers = MCPInventoryService.discoverServerNames()
+        if let allowed = settings.enabledMCPServers {
+            restrictMCPServers = true
+            enabledMCPSelection = Set(allowed)
+        } else {
+            restrictMCPServers = false
+            enabledMCPSelection = []
+        }
     }
 
     private func save() {
@@ -184,6 +213,9 @@ struct GlobalSettingsSheet: View {
 
     private func commitSave(hosts: [String]) {
         settings.passthroughHosts = hosts
+        settings.enabledMCPServers = restrictMCPServers
+            ? enabledMCPSelection.sorted()
+            : nil
 
         let store = WorkspaceStore()
         do {

--- a/AirlockApp/Sources/AirlockApp/Views/Settings/WorkspaceSettingsView.swift
+++ b/AirlockApp/Sources/AirlockApp/Views/Settings/WorkspaceSettingsView.swift
@@ -7,6 +7,9 @@ struct WorkspaceSettingsView: View {
     @State private var globalSettings = AppSettings()
     @State private var passthroughText = ""
     @State private var showRemoveAnthropicConfirm = false
+    @State private var discoveredMCPServers: [String] = []
+    @State private var overrideMCPServers = false
+    @State private var workspaceMCPSelection: Set<String> = []
 
     var body: some View {
         Form {
@@ -71,6 +74,26 @@ struct WorkspaceSettingsView: View {
                 }
             }
 
+            Section("MCP Servers Override") {
+                MCPAllowListPicker(
+                    enabled: $overrideMCPServers,
+                    selection: $workspaceMCPSelection,
+                    discovered: discoveredMCPServers,
+                    toggleLabel: "Override global MCP setting",
+                    restrictedCaption: "Only the checked MCP servers will be active in this workspace.",
+                    unrestrictedCaption: inheritedMCPDescription,
+                    emptyInventoryCaption: "No MCP servers found in ~/.claude/settings.json.",
+                    noneSelectedWarning: "No MCP servers will be available in this workspace."
+                )
+                .onChange(of: overrideMCPServers) { _, newValue in
+                    if !newValue {
+                        workspaceMCPSelection = []
+                    } else if let global = globalSettings.enabledMCPServers {
+                        workspaceMCPSelection = Set(global)
+                    }
+                }
+            }
+
             if appState.isActive(workspace) {
                 HStack(spacing: 6) {
                     Image(systemName: "info.circle")
@@ -103,9 +126,26 @@ struct WorkspaceSettingsView: View {
         }
     }
 
+    private var inheritedMCPDescription: String {
+        if let global = globalSettings.enabledMCPServers {
+            return global.isEmpty
+                ? "Inheriting global setting (no MCP servers enabled)."
+                : "Inheriting global setting: \(global.joined(separator: ", "))."
+        }
+        return "Inheriting global setting (all MCP servers enabled)."
+    }
+
     private func load() {
         globalSettings = (try? WorkspaceStore().loadSettings()) ?? AppSettings()
         passthroughText = workspace.passthroughHostsOverride?.joined(separator: "\n") ?? ""
+        discoveredMCPServers = MCPInventoryService.discoverServerNames()
+        if let override = workspace.enabledMCPServersOverride {
+            overrideMCPServers = true
+            workspaceMCPSelection = Set(override)
+        } else {
+            overrideMCPServers = false
+            workspaceMCPSelection = []
+        }
     }
 
     private func save() {
@@ -124,6 +164,9 @@ struct WorkspaceSettingsView: View {
     private func commitSave(hosts: [String]) {
         if let idx = appState.workspaces.firstIndex(where: { $0.id == workspace.id }) {
             appState.workspaces[idx].passthroughHostsOverride = hosts.isEmpty ? nil : hosts
+            appState.workspaces[idx].enabledMCPServersOverride = overrideMCPServers
+                ? workspaceMCPSelection.sorted()
+                : nil
         }
         try? WorkspaceStore().saveWorkspaces(appState.workspaces)
     }

--- a/AirlockApp/Tests/AirlockAppTests/AppStateTests.swift
+++ b/AirlockApp/Tests/AirlockAppTests/AppStateTests.swift
@@ -65,16 +65,19 @@ final class AppStateTests: XCTestCase {
         global.containerImage = "default:v1"
         global.proxyImage = "default-proxy:v1"
         global.passthroughHosts = ["host1.com"]
+        global.enabledMCPServers = ["slack", "github", "jira"]
         var ws = Workspace(name: "test", path: "/tmp")
         ws.containerImageOverride = "custom:v2"
         ws.proxyImageOverride = "custom-proxy:v2"
         ws.passthroughHostsOverride = ["host2.com"]
         ws.proxyPortOverride = 9090
+        ws.enabledMCPServersOverride = ["slack"]
         let resolved = ResolvedSettings(global: global, workspace: ws)
         XCTAssertEqual(resolved.containerImage, "custom:v2")
         XCTAssertEqual(resolved.proxyImage, "custom-proxy:v2")
         XCTAssertEqual(resolved.passthroughHosts, ["host2.com"])
         XCTAssertEqual(resolved.proxyPort, 9090)
+        XCTAssertEqual(resolved.enabledMCPServers, ["slack"])
     }
 
     func testResolvedSettingsFallsBackToGlobal() {
@@ -82,12 +85,32 @@ final class AppStateTests: XCTestCase {
         global.containerImage = "global:latest"
         global.proxyImage = "global-proxy:latest"
         global.passthroughHosts = ["api.example.com"]
+        global.enabledMCPServers = ["slack"]
         let ws = Workspace(name: "test", path: "/tmp")
         let resolved = ResolvedSettings(global: global, workspace: ws)
         XCTAssertEqual(resolved.containerImage, "global:latest")
         XCTAssertEqual(resolved.proxyImage, "global-proxy:latest")
         XCTAssertEqual(resolved.passthroughHosts, ["api.example.com"])
         XCTAssertEqual(resolved.proxyPort, 8080)
+        XCTAssertEqual(resolved.enabledMCPServers, ["slack"])
+    }
+
+    func testResolvedSettingsNilMCPMeansAllEnabled() {
+        // Both global and workspace nil => nil (meaning: do not filter, keep all MCPs)
+        let global = AppSettings()
+        let ws = Workspace(name: "test", path: "/tmp")
+        let resolved = ResolvedSettings(global: global, workspace: ws)
+        XCTAssertNil(resolved.enabledMCPServers)
+    }
+
+    func testResolvedSettingsEmptyOverrideMeansNoneEnabled() {
+        // Workspace explicitly sets empty array => empty (filter out all MCPs)
+        var global = AppSettings()
+        global.enabledMCPServers = ["slack"]
+        var ws = Workspace(name: "test", path: "/tmp")
+        ws.enabledMCPServersOverride = []
+        let resolved = ResolvedSettings(global: global, workspace: ws)
+        XCTAssertEqual(resolved.enabledMCPServers, [])
     }
 
     func testDetailTabCases() {

--- a/AirlockApp/Tests/AirlockAppTests/MCPInventoryServiceTests.swift
+++ b/AirlockApp/Tests/AirlockAppTests/MCPInventoryServiceTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import AirlockApp
+
+final class MCPInventoryServiceTests: XCTestCase {
+    private func makeHomeWithSettings(_ settings: [String: Any], local: [String: Any]? = nil) throws -> URL {
+        let home = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("airlock-mcp-test-\(UUID().uuidString)")
+        let claudeDir = home.appendingPathComponent(".claude")
+        try FileManager.default.createDirectory(at: claudeDir, withIntermediateDirectories: true)
+        let data = try JSONSerialization.data(withJSONObject: settings)
+        try data.write(to: claudeDir.appendingPathComponent("settings.json"))
+        if let local {
+            let localData = try JSONSerialization.data(withJSONObject: local)
+            try localData.write(to: claudeDir.appendingPathComponent("settings.local.json"))
+        }
+        return home
+    }
+
+    func testDiscoversMCPServersFromGlobalSettings() throws {
+        let home = try makeHomeWithSettings([
+            "mcpServers": [
+                "slack": ["command": "npx"],
+                "github": ["command": "npx"],
+            ],
+        ])
+        let names = MCPInventoryService.discoverServerNames(homeDirectory: home)
+        XCTAssertEqual(names, ["github", "slack"])
+    }
+
+    func testReturnsEmptyArrayWhenNoSettingsFile() {
+        let home = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("airlock-mcp-empty-\(UUID().uuidString)")
+        let names = MCPInventoryService.discoverServerNames(homeDirectory: home)
+        XCTAssertEqual(names, [])
+    }
+
+    func testReturnsEmptyArrayWhenSettingsHasNoMCPServers() throws {
+        let home = try makeHomeWithSettings(["env": ["FOO": "bar"]])
+        let names = MCPInventoryService.discoverServerNames(homeDirectory: home)
+        XCTAssertEqual(names, [])
+    }
+
+    func testMergesGlobalAndLocalSettings() throws {
+        let home = try makeHomeWithSettings(
+            ["mcpServers": ["slack": ["command": "npx"]]],
+            local: ["mcpServers": ["jira": ["command": "npx"]]]
+        )
+        let names = MCPInventoryService.discoverServerNames(homeDirectory: home)
+        XCTAssertEqual(names, ["jira", "slack"])
+    }
+
+    func testDeduplicatesAcrossSettingsFiles() throws {
+        let home = try makeHomeWithSettings(
+            ["mcpServers": ["slack": ["command": "npx"]]],
+            local: ["mcpServers": ["slack": ["command": "npx-override"]]]
+        )
+        let names = MCPInventoryService.discoverServerNames(homeDirectory: home)
+        XCTAssertEqual(names, ["slack"])
+    }
+}

--- a/AirlockApp/Tests/AirlockAppTests/WorkspaceTests.swift
+++ b/AirlockApp/Tests/AirlockAppTests/WorkspaceTests.swift
@@ -43,6 +43,7 @@ final class WorkspaceTests: XCTestCase {
         XCTAssertNil(ws.proxyImageOverride)
         XCTAssertNil(ws.passthroughHostsOverride)
         XCTAssertNil(ws.proxyPortOverride)
+        XCTAssertNil(ws.enabledMCPServersOverride)
     }
 
     func testOverrideFieldsPersisted() throws {
@@ -50,11 +51,24 @@ final class WorkspaceTests: XCTestCase {
         ws.proxyImageOverride = "custom-proxy:v2"
         ws.passthroughHostsOverride = ["api.example.com"]
         ws.proxyPortOverride = 9090
+        ws.enabledMCPServersOverride = ["slack", "github"]
         let data = try JSONEncoder().encode(ws)
         let decoded = try JSONDecoder().decode(Workspace.self, from: data)
         XCTAssertEqual(decoded.proxyImageOverride, "custom-proxy:v2")
         XCTAssertEqual(decoded.passthroughHostsOverride, ["api.example.com"])
         XCTAssertEqual(decoded.proxyPortOverride, 9090)
+        XCTAssertEqual(decoded.enabledMCPServersOverride, ["slack", "github"])
+    }
+
+    func testEmptyMCPOverrideMeansNoneEnabled() throws {
+        // Empty array is a valid explicit override (none enabled),
+        // distinct from nil (inherit global).
+        var ws = Workspace(name: "test", path: "/tmp")
+        ws.enabledMCPServersOverride = []
+        let data = try JSONEncoder().encode(ws)
+        let decoded = try JSONDecoder().decode(Workspace.self, from: data)
+        XCTAssertNotNil(decoded.enabledMCPServersOverride)
+        XCTAssertEqual(decoded.enabledMCPServersOverride, [])
     }
 
     func testBackwardsCompatDecoding() throws {
@@ -68,6 +82,7 @@ final class WorkspaceTests: XCTestCase {
         XCTAssertNil(decoded.proxyImageOverride)
         XCTAssertNil(decoded.passthroughHostsOverride)
         XCTAssertNil(decoded.proxyPortOverride)
+        XCTAssertNil(decoded.enabledMCPServersOverride)
     }
 
     func testTerminalSessionCreation() {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,8 @@
 | `airlock secret env list [--json]` | List registered env secret names |
 | `airlock secret env show <name> [--json]` | Show env secret metadata (truncated ciphertext prefix; never decrypts) |
 | `airlock secret env remove <name>` | Unregister an env secret |
+| `airlock run --enabled-mcps slack,github` | Restrict the agent container to a subset of MCP servers (allow-list). Empty value with the flag disables all MCPs. Omit the flag entirely to keep all MCPs from `settings.json`. |
+| `airlock start --enabled-mcps slack,github` | Same allow-list semantic for the GUI-driven detached `start` command |
 
 ## Architecture
 
@@ -63,6 +65,7 @@ The Go CLI (`cmd/airlock/`) orchestrates both containers. Container management i
 - In SwiftUI views that take `let workspace: Workspace`, custom `Binding` getters must read from `appState.workspaces` (the source of truth), not the `let workspace` parameter. The parameter is a snapshot captured at view creation -- the getter returns the stale value after the setter mutates `appState.workspaces[idx]`, causing TextFields to revert on keystroke.
 - The `.app` bundle embeds the Go CLI at `Contents/MacOS/airlock` (sibling to the Swift binary). `CLIService.resolveAirlockBinary()` checks this path via `Bundle.main.executableURL` before falling back to `$PATH`. See [ADR-0009](docs/decisions/ADR-0009-macos-app-bundling.md).
 - Icon Canvas drawing logic exists in TWO files: `AirlockApp/Sources/AirlockApp/Views/AppIconView.swift` (runtime dock icon) and `scripts/generate-icon-main.swift` (build-time `.icns` generation). Visual changes must be made in both. Duplication is required because the SPM `@main` executable target cannot be imported as a library.
+- `Config.EnabledMCPServers` uses a tri-state: `nil` = no filtering (default, all MCPs enabled), `[]` = filter all (no MCPs), `[..]` = allow only the listed names. The YAML tag intentionally omits `omitempty` because yaml.v3 collapses both nil and empty slices on Save/Load, which would silently flip the security-relevant "filter all" state to "no filtering". The scanner filter runs BEFORE the secret-encryption loop in `scanner_claude.go` so secrets of disabled MCPs never enter the proxy mapping. Reordering those two blocks would leak plaintext credentials.
 
 ## Documentation
 

--- a/docs/guides/security-model.md
+++ b/docs/guides/security-model.md
@@ -75,6 +75,19 @@ At session start, `ResolvedSettings.passthroughHosts = workspace.passthroughHost
 
 **Response audit logging:** The proxy logs response metadata (status code, content type, size) for all traffic. Response body content is never logged.
 
+### Layer 4: MCP Server Allow-List
+
+A per-workspace allow-list restricts which MCP servers from `~/.claude/settings.json` are exposed to the agent container. Filtering happens at scan time in `ClaudeScanner.processFile`: entries in `mcpServers` whose names are not on the allow-list are removed from the in-memory JSON before the shadow mount is written. Their secrets are never registered in the proxy mapping, so a disabled MCP cannot leak credentials even if some other code path tries to substitute them later.
+
+The allow-list is tri-state: `nil` = no filtering (default; all MCPs from settings.json are exposed), `[]` = filter out all MCPs, `[..]` = expose only the named entries. The same `global default + per-workspace override` pattern as passthrough hosts applies, with one important difference: empty lists round-trip safely through `config.yaml` because `Config.EnabledMCPServers` intentionally omits the `omitempty` YAML tag.
+
+The GUI exposes this in two places:
+
+- **Global Settings → MCP Servers** seeds the install-wide default. Toggling `Restrict available MCP servers` exposes a checkbox picker populated from `~/.claude/settings.json` via `MCPInventoryService`.
+- **Workspace Settings → MCP Servers Override** mirrors the picker per workspace. Enabling the override seeds the selection from the global default; clearing the override falls back to the global setting.
+
+The CLI exposes the same control via `airlock run --enabled-mcps slack,github` and `airlock start --enabled-mcps slack,github`. An empty value with the flag (`--enabled-mcps ""`) explicitly disables all MCPs; omitting the flag preserves the existing behavior.
+
 ## What This Protects
 
 | Threat | Protected? | How |
@@ -83,6 +96,7 @@ At session start, `ResolvedSettings.passthroughHosts = workspace.passthroughHost
 | Secret in generated code | Yes | Code contains `ENC[age:...]`, not real keys |
 | Secret pushed to public repo | Yes | Encrypted values are safe to publish |
 | Unauthorized API calls | Partially | Proxy routes all traffic, could add allowlists |
+| Untrusted MCP servers | Partially | Per-workspace allow-list filters mcpServers map at scan time (Layer 4) |
 | Container breakout | Partially | cap-drop=ALL, but kernel exploits possible |
 | Host compromise | No | Private key is on the host |
 

--- a/internal/cli/config_export.go
+++ b/internal/cli/config_export.go
@@ -43,12 +43,8 @@ var configExportCmd = &cobra.Command{
 		if err := os.MkdirAll(dstDir, 0o700); err != nil {
 			return fmt.Errorf("create export directory: %w", err)
 		}
-		var items []string
-		if exportItems != "" {
-			for _, item := range strings.Split(exportItems, ",") {
-				items = append(items, strings.TrimSpace(item))
-			}
-		} else {
+		items := parseCSVList(exportItems)
+		if len(items) == 0 {
 			items = append(items, defaultImportItems...)
 		}
 		for _, item := range items {

--- a/internal/cli/config_import.go
+++ b/internal/cli/config_import.go
@@ -67,12 +67,11 @@ Existing files in the volume are skipped unless --force is set.`,
 		var items []string
 		if importAll {
 			items = append(append(items, defaultImportItems...), optionalImportItems...)
-		} else if importItems != "" {
-			for _, item := range strings.Split(importItems, ",") {
-				items = append(items, strings.TrimSpace(item))
-			}
 		} else {
-			items = append(items, defaultImportItems...)
+			items = parseCSVList(importItems)
+			if len(items) == 0 {
+				items = append(items, defaultImportItems...)
+			}
 		}
 		for _, item := range items {
 			if !allowedImportItems[item] {

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -1,0 +1,23 @@
+package cli
+
+import "strings"
+
+// parseCSVList splits a comma-separated CLI flag value into a trimmed,
+// non-empty list. Always returns a non-nil slice (empty input → []string{})
+// so callers can distinguish "flag set to empty" (empty slice) from "flag
+// not present" (nil, handled separately by checking cmd.Flags().Changed).
+//
+// Empty entries between commas (e.g., "foo,,bar" or trailing ",") are
+// silently dropped — the previous hand-rolled implementations across
+// commands accidentally produced phantom empty-string entries on those
+// inputs.
+func parseCSVList(raw string) []string {
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if s := strings.TrimSpace(p); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/cli/flags_test.go
+++ b/internal/cli/flags_test.go
@@ -1,0 +1,36 @@
+package cli
+
+import "testing"
+
+func TestParseCSVList(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty input returns non-nil empty slice", "", []string{}},
+		{"single value", "foo", []string{"foo"}},
+		{"multiple values", "foo,bar,baz", []string{"foo", "bar", "baz"}},
+		{"trims whitespace", " foo , bar ", []string{"foo", "bar"}},
+		{"drops empty entries between commas", "foo,,bar", []string{"foo", "bar"}},
+		{"drops trailing empty entries", "foo,bar,", []string{"foo", "bar"}},
+		{"drops leading empty entries", ",foo,bar", []string{"foo", "bar"}},
+		{"all whitespace returns empty", "  ", []string{}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseCSVList(tc.in)
+			if got == nil {
+				t.Fatalf("expected non-nil slice for %q, got nil", tc.in)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("len mismatch for %q: got %v, want %v", tc.in, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("[%d] for %q: got %q, want %q", i, tc.in, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -17,12 +16,13 @@ import (
 )
 
 var (
-	runWorkspace        string
-	runEnvFile          string
-	runPassthroughHosts string
-	runProxyPort        int
-	runContainerImage   string
-	runProxyImage       string
+	runWorkspace         string
+	runEnvFile           string
+	runPassthroughHosts  string
+	runProxyPort         int
+	runContainerImage    string
+	runProxyImage        string
+	runEnabledMCPServers string
 )
 
 var runCmd = &cobra.Command{
@@ -43,18 +43,10 @@ All airlock commands must be run from the project root (where .airlock/ is).`,
 		}
 
 		if cmd.Flags().Changed("passthrough-hosts") {
-			if runPassthroughHosts == "" {
-				cfg.PassthroughHosts = nil
-			} else {
-				hosts := strings.Split(runPassthroughHosts, ",")
-				trimmed := make([]string, 0, len(hosts))
-				for _, h := range hosts {
-					if s := strings.TrimSpace(h); s != "" {
-						trimmed = append(trimmed, s)
-					}
-				}
-				cfg.PassthroughHosts = trimmed
-			}
+			cfg.PassthroughHosts = parseCSVList(runPassthroughHosts)
+		}
+		if cmd.Flags().Changed("enabled-mcps") {
+			cfg.EnabledMCPServers = parseCSVList(runEnabledMCPServers)
 		}
 
 		if cmd.Flags().Changed("proxy-port") && runProxyPort > 0 {
@@ -134,6 +126,7 @@ All airlock commands must be run from the project root (where .airlock/ is).`,
 				TmpDir:            tmpDir,
 				VolumeSettingsDir: volSettingsDir,
 				ContainerWorkDir:  fmt.Sprintf("/workspace/%s", wsName),
+				EnabledMCPServers: cfg.EnabledMCPServers,
 			})
 			if err != nil {
 				return fmt.Errorf("scan secrets: %w", err)
@@ -162,5 +155,6 @@ func init() {
 	runCmd.Flags().IntVar(&runProxyPort, "proxy-port", 0, "proxy listening port (overrides config, default 8080)")
 	runCmd.Flags().StringVar(&runContainerImage, "container-image", "", "container image (overrides config)")
 	runCmd.Flags().StringVar(&runProxyImage, "proxy-image", "", "proxy image (overrides config)")
+	runCmd.Flags().StringVar(&runEnabledMCPServers, "enabled-mcps", "", "comma-separated MCP server allow-list (overrides config). Empty value with this flag = disable all MCPs.")
 	rootCmd.AddCommand(runCmd)
 }

--- a/internal/cli/secret_decrypt.go
+++ b/internal/cli/secret_decrypt.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/taeikkim92/airlock/internal/crypto"
@@ -42,8 +41,8 @@ func RunSecretDecrypt(filePath, mode, formatOverride, keysDir string) error {
 	var keySet map[string]bool
 	if mode != "all" {
 		keySet = make(map[string]bool)
-		for _, k := range strings.Split(mode, ",") {
-			keySet[strings.TrimSpace(k)] = true
+		for _, k := range parseCSVList(mode) {
+			keySet[k] = true
 		}
 	}
 

--- a/internal/cli/secret_encrypt.go
+++ b/internal/cli/secret_encrypt.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/taeikkim92/airlock/internal/config"
@@ -59,8 +58,8 @@ func RunSecretEncrypt(filePath, mode, formatOverride, keysDir, airlockDir string
 		}
 	default:
 		keySet = make(map[string]bool)
-		for _, k := range strings.Split(mode, ",") {
-			keySet[strings.TrimSpace(k)] = true
+		for _, k := range parseCSVList(mode) {
+			keySet[k] = true
 		}
 	}
 

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -25,10 +24,28 @@ type StartResult struct {
 	Network   string `json:"network"`
 }
 
+// StartOptions bundles per-flag overrides applied on top of config.yaml.
+// An *Override bool field is used for flags whose presence (vs. value) is
+// significant — e.g., an empty PassthroughHosts string with the override flag
+// clears the config list, while no flag at all preserves it.
+type StartOptions struct {
+	ID                  string
+	Workspace           string
+	EnvFile             string
+	PassthroughHosts    string
+	PassthroughOverride bool
+	ProxyPort           int
+	ContainerImage      string
+	ProxyImage          string
+	EnabledMCPServers   string
+	MCPOverride         bool
+}
+
 // RunStart encapsulates the start logic so it can be tested without cobra.
-// When passthroughOverride is true, passthroughHosts replaces config.yaml
-// (even if empty, which clears the list).
-func RunStart(ctx context.Context, runtime container.ContainerRuntime, id, workspace, envFile, airlockDir, passthroughHosts string, passthroughOverride bool, proxyPort int, containerImage, proxyImage string) (*StartResult, error) {
+// When PassthroughOverride is true, PassthroughHosts replaces config.yaml
+// (even if empty, which clears the list). Same semantic for MCPOverride and
+// EnabledMCPServers.
+func RunStart(ctx context.Context, runtime container.ContainerRuntime, airlockDir string, opts StartOptions) (*StartResult, error) {
 	keysDir := filepath.Join(airlockDir, "keys")
 
 	cfg, err := config.Load(airlockDir)
@@ -36,30 +53,26 @@ func RunStart(ctx context.Context, runtime container.ContainerRuntime, id, works
 		return nil, fmt.Errorf("load config (run 'airlock init' first): %w", err)
 	}
 
-	if passthroughOverride {
-		if passthroughHosts == "" {
-			cfg.PassthroughHosts = nil
-		} else {
-			hosts := strings.Split(passthroughHosts, ",")
-			trimmed := make([]string, 0, len(hosts))
-			for _, h := range hosts {
-				if s := strings.TrimSpace(h); s != "" {
-					trimmed = append(trimmed, s)
-				}
-			}
-			cfg.PassthroughHosts = trimmed
-		}
+	if opts.PassthroughOverride {
+		cfg.PassthroughHosts = parseCSVList(opts.PassthroughHosts)
+	}
+	if opts.MCPOverride {
+		cfg.EnabledMCPServers = parseCSVList(opts.EnabledMCPServers)
 	}
 
-	if proxyPort > 0 {
-		cfg.ProxyPort = proxyPort
+	if opts.ProxyPort > 0 {
+		cfg.ProxyPort = opts.ProxyPort
 	}
-	if containerImage != "" {
-		cfg.ContainerImage = containerImage
+	if opts.ContainerImage != "" {
+		cfg.ContainerImage = opts.ContainerImage
 	}
-	if proxyImage != "" {
-		cfg.ProxyImage = proxyImage
+	if opts.ProxyImage != "" {
+		cfg.ProxyImage = opts.ProxyImage
 	}
+
+	id := opts.ID
+	workspace := opts.Workspace
+	envFile := opts.EnvFile
 
 	if workspace == "" {
 		workspace, _ = os.Getwd()
@@ -121,6 +134,7 @@ func RunStart(ctx context.Context, runtime container.ContainerRuntime, id, works
 			TmpDir:            tmpDir,
 			VolumeSettingsDir: volSettingsDir,
 			ContainerWorkDir:  fmt.Sprintf("/workspace/%s", wsName),
+			EnabledMCPServers: cfg.EnabledMCPServers,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("scan secrets: %w", err)
@@ -151,13 +165,14 @@ func RunStart(ctx context.Context, runtime container.ContainerRuntime, id, works
 }
 
 var (
-	startID               string
-	startWorkspace        string
-	startEnvFile          string
-	startPassthroughHosts string
-	startProxyPort        int
-	startContainerImage   string
-	startProxyImage       string
+	startID                string
+	startWorkspace         string
+	startEnvFile           string
+	startPassthroughHosts  string
+	startProxyPort         int
+	startContainerImage    string
+	startProxyImage        string
+	startEnabledMCPServers string
 )
 
 var startCmd = &cobra.Command{
@@ -176,7 +191,18 @@ Requires --id to identify this session.`,
 		}
 		defer docker.Close()
 
-		result, err := RunStart(ctx, docker, startID, startWorkspace, startEnvFile, ".airlock", startPassthroughHosts, cmd.Flags().Changed("passthrough-hosts"), startProxyPort, startContainerImage, startProxyImage)
+		result, err := RunStart(ctx, docker, ".airlock", StartOptions{
+			ID:                  startID,
+			Workspace:           startWorkspace,
+			EnvFile:             startEnvFile,
+			PassthroughHosts:    startPassthroughHosts,
+			PassthroughOverride: cmd.Flags().Changed("passthrough-hosts"),
+			ProxyPort:           startProxyPort,
+			ContainerImage:      startContainerImage,
+			ProxyImage:          startProxyImage,
+			EnabledMCPServers:   startEnabledMCPServers,
+			MCPOverride:         cmd.Flags().Changed("enabled-mcps"),
+		})
 		if err != nil {
 			return err
 		}
@@ -196,5 +222,6 @@ func init() {
 	startCmd.Flags().IntVar(&startProxyPort, "proxy-port", 0, "proxy listening port (overrides config, default 8080)")
 	startCmd.Flags().StringVar(&startContainerImage, "container-image", "", "container image (overrides config)")
 	startCmd.Flags().StringVar(&startProxyImage, "proxy-image", "", "proxy image (overrides config)")
+	startCmd.Flags().StringVar(&startEnabledMCPServers, "enabled-mcps", "", "comma-separated MCP server allow-list (overrides config). Empty value with this flag = disable all MCPs.")
 	rootCmd.AddCommand(startCmd)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,17 @@ type Config struct {
 	VolumeName       string             `yaml:"volume_name"`
 	SecretFiles      []SecretFileConfig `yaml:"secret_files,omitempty"`
 	EnvSecrets       []EnvSecretConfig  `yaml:"env_secrets,omitempty"`
+	// EnabledMCPServers, when non-nil, restricts the agent container to only
+	// the named MCP servers. Entries from the user's settings.json that are
+	// not in this list are removed before the file is shadow-mounted into the
+	// container. nil = no filtering (default behavior, all MCPs enabled).
+	// Empty slice = filter out all MCP servers.
+	//
+	// NOTE: `omitempty` is intentionally absent. yaml.v3's omitempty collapses
+	// both nil and empty slices into "field absent on Load", which would
+	// silently flip the security-relevant "filter all" state ([]) to
+	// "no filtering" (nil) on a save/load round-trip.
+	EnabledMCPServers []string `yaml:"enabled_mcp_servers"`
 }
 
 // EnvVarNamePattern is the POSIX env var identifier pattern. Exported so

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -190,6 +190,62 @@ func splitLines(s string) []string {
 	return lines
 }
 
+func TestEnabledMCPServersRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default()
+	cfg.EnabledMCPServers = []string{"slack", "github"}
+	if err := config.Save(cfg, dir); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := config.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.EnabledMCPServers) != 2 {
+		t.Fatalf("expected 2 enabled MCP servers, got %d", len(loaded.EnabledMCPServers))
+	}
+	if loaded.EnabledMCPServers[0] != "slack" || loaded.EnabledMCPServers[1] != "github" {
+		t.Errorf("unexpected MCP server list: %v", loaded.EnabledMCPServers)
+	}
+}
+
+func TestEnabledMCPServersBackwardsCompat(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("container_image: airlock-claude:latest\nproxy_image: airlock-proxy:latest\nnetwork_name: airlock-net\nproxy_port: 8080\nvolume_name: airlock-claude-home\n")
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := config.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.EnabledMCPServers != nil {
+		t.Errorf("expected nil EnabledMCPServers for old config (no filtering), got %v", loaded.EnabledMCPServers)
+	}
+}
+
+func TestEnabledMCPServersEmptyRoundTripPreserved(t *testing.T) {
+	// Empty slice means "filter out all MCPs" — the security-relevant state.
+	// It must round-trip through Save/Load as a non-nil empty slice, NOT
+	// collapse to nil (which would mean "no filtering").
+	dir := t.TempDir()
+	cfg := config.Default()
+	cfg.EnabledMCPServers = []string{}
+	if err := config.Save(cfg, dir); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := config.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.EnabledMCPServers == nil {
+		t.Fatal("expected non-nil empty slice (filter all), got nil (no filtering) — security regression")
+	}
+	if len(loaded.EnabledMCPServers) != 0 {
+		t.Errorf("expected empty slice, got %v", loaded.EnabledMCPServers)
+	}
+}
+
 func TestEnvSecretsRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	cfg := config.Default()

--- a/internal/secrets/scanner.go
+++ b/internal/secrets/scanner.go
@@ -17,6 +17,12 @@ type ScanOpts struct {
 	TmpDir            string
 	VolumeSettingsDir string // when set, read global settings from this dir instead of HomeDir
 	ContainerWorkDir  string // container-side workspace path (e.g., /workspace/my-app)
+
+	// EnabledMCPServers, when non-nil, filters mcpServers in Claude settings
+	// files to only the named entries before they reach the agent container.
+	// nil = do not filter (keep all MCP servers from settings.json).
+	// empty slice = filter out all MCP servers.
+	EnabledMCPServers []string
 }
 
 // ShadowMount describes a file-level Docker bind mount that shadows

--- a/internal/secrets/scanner_claude.go
+++ b/internal/secrets/scanner_claude.go
@@ -86,6 +86,17 @@ func (s *ClaudeScanner) processFile(f claudeSettingsFile, opts ScanOpts) ([]Shad
 	}
 
 	if mcpServers, ok := root["mcpServers"].(map[string]any); ok {
+		// Security-critical ordering: filter out disallowed MCP entries
+		// BEFORE the encrypt loop below. The subsequent loop iterates the
+		// already-filtered map, so secrets belonging to filtered-out MCPs
+		// never enter the proxy mapping. Reordering these two blocks would
+		// leak plaintext credentials of disabled MCPs to the proxy
+		// decryption table.
+		if opts.EnabledMCPServers != nil {
+			if filterMCPServers(mcpServers, opts.EnabledMCPServers) {
+				modified = true
+			}
+		}
 		for _, serverVal := range mcpServers {
 			server, ok := serverVal.(map[string]any)
 			if !ok {
@@ -120,6 +131,24 @@ func (s *ClaudeScanner) processFile(f claudeSettingsFile, opts ScanOpts) ([]Shad
 
 	mount := ShadowMount{HostPath: tmpPath, ContainerPath: f.containerPath}
 	return []ShadowMount{mount}, mapping, nil
+}
+
+// filterMCPServers removes entries from mcpServers whose names are not in the
+// allowed list. Mutates mcpServers in place. Returns true if at least one entry
+// was removed (so the caller knows to re-marshal the shadow mount).
+func filterMCPServers(mcpServers map[string]any, allowed []string) bool {
+	allowSet := make(map[string]struct{}, len(allowed))
+	for _, name := range allowed {
+		allowSet[name] = struct{}{}
+	}
+	removed := false
+	for name := range mcpServers {
+		if _, ok := allowSet[name]; !ok {
+			delete(mcpServers, name)
+			removed = true
+		}
+	}
+	return removed
 }
 
 func encryptEnvBlock(envBlock map[string]any, publicKey string, mapping map[string]string) bool {

--- a/internal/secrets/scanner_claude_test.go
+++ b/internal/secrets/scanner_claude_test.go
@@ -217,6 +217,161 @@ func TestClaudeScannerMissingFile(t *testing.T) {
 	}
 }
 
+func TestClaudeScannerFiltersMCPServersByAllowlist(t *testing.T) {
+	pub, priv := setupTestKeys(t)
+	tmpDir := t.TempDir()
+	homeDir := t.TempDir()
+
+	claudeDir := filepath.Join(homeDir, ".claude")
+	os.MkdirAll(claudeDir, 0755)
+
+	settings := map[string]any{
+		"mcpServers": map[string]any{
+			"slack": map[string]any{
+				"command": "npx",
+				"env":     map[string]any{"SLACK_TOKEN": "xoxb-1234567890-abcdef"},
+			},
+			"github": map[string]any{
+				"command": "npx",
+				"env":     map[string]any{"GITHUB_TOKEN": "ghp_abcdefghijklmnopqrst"},
+			},
+			"jira": map[string]any{
+				"command": "npx",
+				"env":     map[string]any{"JIRA_TOKEN": "ATATT3xFfGF0T5BlAhR56789"},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(settings, "", "  ")
+	os.WriteFile(filepath.Join(claudeDir, "settings.json"), data, 0644)
+
+	scanner := NewClaudeScanner()
+	result, err := scanner.Scan(ScanOpts{
+		Workspace:         tmpDir,
+		HomeDir:           homeDir,
+		PublicKey:         pub,
+		PrivateKey:        priv,
+		TmpDir:            tmpDir,
+		EnabledMCPServers: []string{"slack", "github"},
+	})
+	if err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+	if len(result.Mounts) != 1 {
+		t.Fatalf("expected 1 mount, got %d", len(result.Mounts))
+	}
+
+	processed, _ := os.ReadFile(result.Mounts[0].HostPath)
+	var decoded map[string]any
+	if err := json.Unmarshal(processed, &decoded); err != nil {
+		t.Fatalf("parse shadow mount JSON: %v", err)
+	}
+	mcps, ok := decoded["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatal("mcpServers missing from shadow mount")
+	}
+	if _, ok := mcps["slack"]; !ok {
+		t.Error("slack should be in filtered mcpServers")
+	}
+	if _, ok := mcps["github"]; !ok {
+		t.Error("github should be in filtered mcpServers")
+	}
+	if _, ok := mcps["jira"]; ok {
+		t.Error("jira should be filtered out of mcpServers")
+	}
+	// Mapping should only contain secrets for retained MCPs.
+	if len(result.Mapping) != 2 {
+		t.Errorf("expected 2 mapping entries (slack + github), got %d", len(result.Mapping))
+	}
+	for _, plain := range result.Mapping {
+		if plain == "ATATT3xFfGF0T5BlAhR56789" {
+			t.Error("jira secret must not be in mapping — MCP was filtered out")
+		}
+	}
+}
+
+func TestClaudeScannerEmptyAllowlistFiltersAllMCPServers(t *testing.T) {
+	pub, priv := setupTestKeys(t)
+	tmpDir := t.TempDir()
+	homeDir := t.TempDir()
+
+	claudeDir := filepath.Join(homeDir, ".claude")
+	os.MkdirAll(claudeDir, 0755)
+
+	settings := map[string]any{
+		"env": map[string]any{"ANTHROPIC_API_KEY": "sk-ant-api03-realkey12345"},
+		"mcpServers": map[string]any{
+			"slack": map[string]any{
+				"env": map[string]any{"SLACK_TOKEN": "xoxb-1234567890-abcdef"},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(settings, "", "  ")
+	os.WriteFile(filepath.Join(claudeDir, "settings.json"), data, 0644)
+
+	scanner := NewClaudeScanner()
+	result, err := scanner.Scan(ScanOpts{
+		Workspace:         tmpDir,
+		HomeDir:           homeDir,
+		PublicKey:         pub,
+		PrivateKey:        priv,
+		TmpDir:            tmpDir,
+		EnabledMCPServers: []string{}, // explicit empty = none enabled
+	})
+	if err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+	if len(result.Mounts) != 1 {
+		t.Fatalf("expected 1 mount (top-level env still needs encryption), got %d", len(result.Mounts))
+	}
+	processed, _ := os.ReadFile(result.Mounts[0].HostPath)
+	var decoded map[string]any
+	if err := json.Unmarshal(processed, &decoded); err != nil {
+		t.Fatalf("parse shadow mount JSON: %v", err)
+	}
+	if mcps, ok := decoded["mcpServers"].(map[string]any); ok {
+		if len(mcps) != 0 {
+			t.Errorf("expected mcpServers to be empty, got %v", mcps)
+		}
+	}
+	for _, plain := range result.Mapping {
+		if plain == "xoxb-1234567890-abcdef" {
+			t.Error("slack secret must not be in mapping when allowlist is empty")
+		}
+	}
+}
+
+func TestClaudeScannerNilAllowlistKeepsAllMCPServers(t *testing.T) {
+	pub, priv := setupTestKeys(t)
+	tmpDir := t.TempDir()
+	homeDir := t.TempDir()
+
+	claudeDir := filepath.Join(homeDir, ".claude")
+	os.MkdirAll(claudeDir, 0755)
+
+	settings := map[string]any{
+		"mcpServers": map[string]any{
+			"slack": map[string]any{
+				"env": map[string]any{"SLACK_TOKEN": "xoxb-1234567890-abcdef"},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(settings, "", "  ")
+	os.WriteFile(filepath.Join(claudeDir, "settings.json"), data, 0644)
+
+	scanner := NewClaudeScanner()
+	result, err := scanner.Scan(ScanOpts{
+		Workspace: tmpDir, HomeDir: homeDir,
+		PublicKey: pub, PrivateKey: priv, TmpDir: tmpDir,
+		// EnabledMCPServers omitted => nil => no filtering
+	})
+	if err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+	if len(result.Mapping) != 1 {
+		t.Fatalf("expected 1 mapping entry (slack secret), got %d", len(result.Mapping))
+	}
+}
+
 func TestClaudeScannerProjectAndGlobal(t *testing.T) {
 	pub, priv := setupTestKeys(t)
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Summary

Adds **Layer 4** to the airlock security model — a per-workspace MCP server allow-list that lets users restrict which MCP servers from `~/.claude/settings.json` reach the agent container. Filtering happens at scan time in `ClaudeScanner.processFile` so secrets of disabled MCPs never enter the proxy mapping — disabling an MCP is a privacy property, not just a config toggle.

Closes the pilot-user request for per-workspace MCP control.

## What changed

- **Go scanner** (`internal/secrets/scanner_claude.go`): new `filterMCPServers` helper, runs BEFORE the secret-encryption loop so filtered MCPs' secrets never enter the proxy mapping.
- **Go config/CLI**: new `Config.EnabledMCPServers` field with intentional non-`omitempty` YAML tag (empty slice round-trip must survive), new `--enabled-mcps` flag on `airlock run` and `airlock start`. Added a shared `parseCSVList` helper in `internal/cli/flags.go` and refactored 4 existing CLI commands to use it (incidentally fixing a latent phantom-empty-entry bug in those callers).
- **Swift GUI**: new `Workspace.enabledMCPServersOverride`, `AppSettings.enabledMCPServers`, `ResolvedSettings.enabledMCPServers`. New `MCPInventoryService` reads `~/.claude/settings*.json` to enumerate installed MCPs. New reusable `MCPAllowListPicker` view used by both Global Settings and Workspace Settings sections.
- **CLI glue**: `ContainerSessionService.activate` passes `--enabled-mcps` only when the resolved value is non-nil; nil means "no filtering" and keeps current behavior.

## Architecture decisions

The tri-state semantic is critical:

- `nil` = no filtering (default, back-compat, all MCPs from settings.json are exposed)
- `[]` = filter out all MCPs (security-relevant state)
- `[..]` = expose only the named entries

`Config.EnabledMCPServers` intentionally omits the `omitempty` YAML tag because yaml.v3's omitempty collapses both nil and empty slices into \"field absent on Load\", which would silently flip the security-relevant \"filter all\" state ([]) to \"no filtering\" (nil) on a save/load round-trip. Regression pinned by `TestEnabledMCPServersEmptyRoundTripPreserved`.

## Tests

- **Go**: 7 packages pass with `-race -cover`. Scanner coverage 85.3%, config 93.1%.
  - `TestClaudeScannerFiltersMCPServersByAllowlist` — allow-list applies
  - `TestClaudeScannerEmptyAllowlistFiltersAllMCPServers` — security invariant: no secrets leak for filtered MCPs
  - `TestClaudeScannerNilAllowlistKeepsAllMCPServers` — back-compat
  - `TestEnabledMCPServersRoundTrip`, `TestEnabledMCPServersBackwardsCompat`, `TestEnabledMCPServersEmptyRoundTripPreserved` — YAML persistence
  - `TestParseCSVList` (8 cases) covering empty + phantom-trailer cases
- **Swift**: 63 → 76 tests (13 new) covering:
  - `testOverrideFieldsPersisted`, `testEmptyMCPOverrideMeansNoneEnabled`
  - `testResolvedSettingsNilMCPMeansAllEnabled`, `testResolvedSettingsEmptyOverrideMeansNoneEnabled`
  - `MCPInventoryServiceTests` (5 cases)

## Simplify + review-fix loop findings addressed

- **CRITICAL**: YAML `omitempty` was silently flipping `[]` to `nil` on round-trip. Dropped tag, added regression test.
- **HIGH**: Extracted `MCPAllowListPicker` shared view to eliminate ~30 lines of duplication between Global and Workspace Settings sections.
- **HIGH**: Added security-intent comment at the `filterMCPServers` call site explaining why filter must run before the encryption loop.
- **MEDIUM**: Promoted `parseCSVList` to shared `flags.go` and reused in 4 other CLI commands (also fixes latent phantom-empty-entry bug).

## Test plan

- [x] `make test` — 7 Go packages, `-race -cover`, all green
- [x] `make gui-test` — 76 Swift tests pass
- [x] `go vet ./...` clean
- [x] Scanner security invariant: secrets of filtered-out MCPs do NOT appear in the proxy mapping (`TestClaudeScannerFiltersMCPServersByAllowlist` asserts this)

## Notes on branch history

This PR is a retroactive branch extraction for a commit that was previously pushed only to local `main` (committed direct-to-main in error during the original dev session). The commit hash (`078635d`) is unchanged — this branch simply gives it a GitHub PR for proper review/audit history before it reaches `origin/main`. No history rewrite of any shared ref.

Companion PR #24 (`feat: per-workspace network allow-list`) builds on this work and will be rebased on top of `main` once this merges.