### PR TITLE
feat: GUI minor fixes (passthrough toggles, remove .env legacy)

### DIFF
--- a/AirlockApp/Sources/AirlockApp/Models/AppState.swift
+++ b/AirlockApp/Sources/AirlockApp/Models/AppState.swift
@@ -181,6 +181,11 @@ struct AppSettings: Codable, Equatable {
     var containerImage: String = "airlock-claude:latest"
     var proxyImage: String = "airlock-proxy:latest"
     var passthroughHosts: [String] = ["api.anthropic.com", "auth.anthropic.com"]
+    /// Editor text to restore when the global passthrough toggle is OFF.
+    /// Never read by the CLI layer; used only by `SettingsView` to preserve
+    /// the user's in-progress host list across app restarts while the
+    /// toggle is disabled. Nil when the toggle is ON.
+    var passthroughHostsDraft: [String]?
     var enabledMCPServers: [String]?
     var networkAllowlist: [String]?
     var theme: AppTheme = .system
@@ -194,6 +199,7 @@ struct AppSettings: Codable, Equatable {
         containerImage = try container.decodeIfPresent(String.self, forKey: .containerImage) ?? "airlock-claude:latest"
         proxyImage = try container.decodeIfPresent(String.self, forKey: .proxyImage) ?? "airlock-proxy:latest"
         passthroughHosts = try container.decodeIfPresent([String].self, forKey: .passthroughHosts) ?? ["api.anthropic.com", "auth.anthropic.com"]
+        passthroughHostsDraft = try container.decodeIfPresent([String].self, forKey: .passthroughHostsDraft)
         enabledMCPServers = try container.decodeIfPresent([String].self, forKey: .enabledMCPServers)
         networkAllowlist = try container.decodeIfPresent([String].self, forKey: .networkAllowlist)
         theme = try container.decodeIfPresent(AppTheme.self, forKey: .theme) ?? .system

--- a/AirlockApp/Sources/AirlockApp/Views/Settings/SettingsView.swift
+++ b/AirlockApp/Sources/AirlockApp/Views/Settings/SettingsView.swift
@@ -188,10 +188,7 @@ struct GlobalSettingsSheet: View {
                 proceedAfterPassthroughConfirmed()
             }
         } message: {
-            let missing = PassthroughPolicy.missingProtectedHosts(
-                from: PassthroughPolicy.splitHostLines(passthroughText)
-            )
-            Text("\(missing.joined(separator: ", ")) will be removed from passthrough. Airlock will then decrypt secrets in requests to Anthropic, sending your plaintext credentials to Anthropic's servers. Continue?")
+            Text("\(passthroughMissingProtectedHosts.joined(separator: ", ")) will be removed from passthrough. Airlock will then decrypt secrets in requests to Anthropic, sending your plaintext credentials to Anthropic's servers. Continue?")
         }
         .alert("Allow-list blocks Anthropic?", isPresented: $showAllowlistAnthropicConfirm) {
             Button("Cancel", role: .cancel) {}
@@ -246,6 +243,17 @@ struct GlobalSettingsSheet: View {
         }
     }
 
+    /// Protected Anthropic hosts missing from the passthrough list we are
+    /// about to save. Uses the toggle state so the alert message and the
+    /// guardrail check see the same "parsed" value: toggle OFF means we
+    /// are saving `[]` regardless of what the editor shows.
+    private var passthroughMissingProtectedHosts: [String] {
+        let parsed = enablePassthrough
+            ? PassthroughPolicy.splitHostLines(passthroughText)
+            : []
+        return PassthroughPolicy.missingProtectedHosts(from: parsed)
+    }
+
     private func save() {
         // Guardrails chain: passthrough → allow-list → commit. Each alert's
         // "confirm anyway" button re-enters this chain via the next helper
@@ -256,11 +264,7 @@ struct GlobalSettingsSheet: View {
         // (meaning proxy decrypts everything). missingProtectedHosts([])
         // returns the full protected set, so the guardrail still fires —
         // disabling passthrough is always a confirmed action.
-        let parsed = enablePassthrough
-            ? PassthroughPolicy.splitHostLines(passthroughText)
-            : []
-        let missing = PassthroughPolicy.missingProtectedHosts(from: parsed)
-        if !missing.isEmpty {
+        if !passthroughMissingProtectedHosts.isEmpty {
             showRemoveAnthropicConfirm = true
             return
         }

--- a/AirlockApp/Sources/AirlockApp/Views/Settings/SettingsView.swift
+++ b/AirlockApp/Sources/AirlockApp/Views/Settings/SettingsView.swift
@@ -193,7 +193,7 @@ struct GlobalSettingsSheet: View {
         .alert("Allow-list blocks Anthropic?", isPresented: $showAllowlistAnthropicConfirm) {
             Button("Cancel", role: .cancel) {}
             Button("Save anyway", role: .destructive) {
-                commitSave(hosts: enablePassthrough ? PassthroughPolicy.splitHostLines(passthroughText) : [])
+                commitSave()
             }
         } message: {
             let missing = NetworkAllowlistPolicy.missingProtectedHosts(
@@ -279,12 +279,12 @@ struct GlobalSettingsSheet: View {
                 return
             }
         }
-        commitSave(hosts: enablePassthrough ? PassthroughPolicy.splitHostLines(passthroughText) : [])
+        commitSave()
     }
 
-    private func commitSave(hosts: [String]) {
+    private func commitSave() {
         if enablePassthrough {
-            settings.passthroughHosts = hosts
+            settings.passthroughHosts = PassthroughPolicy.splitHostLines(passthroughText)
             settings.passthroughHostsDraft = nil
         } else {
             settings.passthroughHosts = []

--- a/AirlockApp/Sources/AirlockApp/Views/Settings/SettingsView.swift
+++ b/AirlockApp/Sources/AirlockApp/Views/Settings/SettingsView.swift
@@ -6,6 +6,7 @@ struct GlobalSettingsSheet: View {
     @Environment(\.dismiss) private var dismiss
     @State private var settings = AppSettings()
     @State private var passthroughText = ""
+    @State private var enablePassthrough = true
     @State private var saved = false
     @State private var volumeStatus = "Checking..."
     @State private var showImportSheet = false
@@ -67,17 +68,24 @@ struct GlobalSettingsSheet: View {
                     TextField("Proxy image", text: $settings.proxyImage)
                 }
 
-                Section("Network Defaults") {
-                    HostListEditor(
-                        caption: "Default passthrough hosts (skip proxy decryption, one per line)",
-                        text: $passthroughText,
-                        missingHosts: PassthroughPolicy.missingProtectedHosts(
-                            from: PassthroughPolicy.splitHostLines(passthroughText)
-                        ),
-                        warningText: { joined in
-                            "Removing \(joined) from passthrough means Airlock will decrypt secrets in requests to Anthropic. Your plaintext credentials will be sent to Anthropic's servers. This defeats the purpose of Airlock — only remove for testing."
-                        }
-                    )
+                Section("Passthrough Hosts") {
+                    Toggle("Enable passthrough hosts", isOn: $enablePassthrough)
+                    if enablePassthrough {
+                        HostListEditor(
+                            caption: "Passthrough hosts skip proxy decryption (one per line). Anthropic endpoints belong here so credentials stay encrypted in transit.",
+                            text: $passthroughText,
+                            missingHosts: PassthroughPolicy.missingProtectedHosts(
+                                from: PassthroughPolicy.splitHostLines(passthroughText)
+                            ),
+                            warningText: { joined in
+                                "Removing \(joined) from passthrough means Airlock will decrypt secrets in requests to Anthropic. Your plaintext credentials will be sent to Anthropic's servers. This defeats the purpose of Airlock — only remove for testing."
+                            }
+                        )
+                    } else {
+                        Text("All outbound HTTPS, including Anthropic, will flow through the proxy for secret decryption. Your plaintext credentials will be sent to Anthropic's servers.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
 
                 Section("MCP Servers") {
@@ -188,7 +196,7 @@ struct GlobalSettingsSheet: View {
         .alert("Allow-list blocks Anthropic?", isPresented: $showAllowlistAnthropicConfirm) {
             Button("Cancel", role: .cancel) {}
             Button("Save anyway", role: .destructive) {
-                commitSave(hosts: PassthroughPolicy.splitHostLines(passthroughText))
+                commitSave(hosts: enablePassthrough ? PassthroughPolicy.splitHostLines(passthroughText) : [])
             }
         } message: {
             let missing = NetworkAllowlistPolicy.missingProtectedHosts(
@@ -211,7 +219,16 @@ struct GlobalSettingsSheet: View {
     private func load() {
         let store = WorkspaceStore()
         settings = (try? store.loadSettings()) ?? AppSettings()
-        passthroughText = settings.passthroughHosts.joined(separator: "\n")
+        if settings.passthroughHosts.isEmpty {
+            // Toggle OFF state — show the persisted draft (if any) so the
+            // user sees whatever they were working on before they turned
+            // passthrough off. Nil draft => empty editor.
+            enablePassthrough = false
+            passthroughText = (settings.passthroughHostsDraft ?? []).joined(separator: "\n")
+        } else {
+            enablePassthrough = true
+            passthroughText = settings.passthroughHosts.joined(separator: "\n")
+        }
         discoveredMCPServers = MCPInventoryService.discoverServerNames()
         if let allowed = settings.enabledMCPServers {
             restrictMCPServers = true
@@ -234,7 +251,14 @@ struct GlobalSettingsSheet: View {
         // "confirm anyway" button re-enters this chain via the next helper
         // so users see BOTH warnings if they're both violated, instead of
         // silently losing the second alert after confirming the first.
-        let parsed = PassthroughPolicy.splitHostLines(passthroughText)
+        //
+        // When the passthrough toggle is OFF, the stored host list is []
+        // (meaning proxy decrypts everything). missingProtectedHosts([])
+        // returns the full protected set, so the guardrail still fires —
+        // disabling passthrough is always a confirmed action.
+        let parsed = enablePassthrough
+            ? PassthroughPolicy.splitHostLines(passthroughText)
+            : []
         let missing = PassthroughPolicy.missingProtectedHosts(from: parsed)
         if !missing.isEmpty {
             showRemoveAnthropicConfirm = true
@@ -251,11 +275,20 @@ struct GlobalSettingsSheet: View {
                 return
             }
         }
-        commitSave(hosts: PassthroughPolicy.splitHostLines(passthroughText))
+        commitSave(hosts: enablePassthrough ? PassthroughPolicy.splitHostLines(passthroughText) : [])
     }
 
     private func commitSave(hosts: [String]) {
-        settings.passthroughHosts = hosts
+        if enablePassthrough {
+            settings.passthroughHosts = hosts
+            settings.passthroughHostsDraft = nil
+        } else {
+            settings.passthroughHosts = []
+            // Preserve whatever is currently in the editor so the user can
+            // flip the toggle back ON later and see their previous list.
+            let draft = PassthroughPolicy.splitHostLines(passthroughText)
+            settings.passthroughHostsDraft = draft.isEmpty ? nil : draft
+        }
         settings.enabledMCPServers = restrictMCPServers
             ? enabledMCPSelection.sorted()
             : nil

--- a/AirlockApp/Sources/AirlockApp/Views/Settings/WorkspaceSettingsView.swift
+++ b/AirlockApp/Sources/AirlockApp/Views/Settings/WorkspaceSettingsView.swift
@@ -129,10 +129,7 @@ struct WorkspaceSettingsView: View {
                 proceedAfterPassthroughConfirmed()
             }
         } message: {
-            let missing = PassthroughPolicy.missingProtectedHosts(
-                from: PassthroughPolicy.splitHostLines(passthroughText)
-            )
-            Text("\(missing.joined(separator: ", ")) will not be in this workspace's passthrough list. Airlock will decrypt secrets in requests to Anthropic, sending your plaintext credentials to Anthropic's servers. Continue?")
+            Text("\(passthroughOverrideMissingHosts.joined(separator: ", ")) will not be in this workspace's passthrough list. Airlock will decrypt secrets in requests to Anthropic, sending your plaintext credentials to Anthropic's servers. Continue?")
         }
         .alert("Allow-list blocks Anthropic in this workspace?", isPresented: $showAllowlistAnthropicConfirm) {
             Button("Cancel", role: .cancel) {}
@@ -212,17 +209,13 @@ struct WorkspaceSettingsView: View {
         // "confirm anyway" button re-enters this chain via the next helper
         // so users see BOTH warnings if they're both violated.
         //
-        // The override toggle gates the passthrough guardrail: OFF = inherit
-        // global (safe, no check). ON = check the editor contents, including
-        // the empty-editor case which now means "explicitly no passthrough
-        // for this workspace".
-        if overridePassthrough {
-            let hosts = PassthroughPolicy.splitHostLines(passthroughText)
-            let missing = PassthroughPolicy.missingProtectedHosts(from: hosts)
-            if !missing.isEmpty {
-                showRemoveAnthropicConfirm = true
-                return
-            }
+        // `passthroughOverrideMissingHosts` already handles the toggle gate:
+        // when the toggle is OFF it returns empty (inherit is safe); when
+        // ON it checks the editor contents, including the empty-editor case
+        // which now means "explicitly no passthrough for this workspace".
+        if !passthroughOverrideMissingHosts.isEmpty {
+            showRemoveAnthropicConfirm = true
+            return
         }
         proceedAfterPassthroughConfirmed()
     }

--- a/AirlockApp/Sources/AirlockApp/Views/Settings/WorkspaceSettingsView.swift
+++ b/AirlockApp/Sources/AirlockApp/Views/Settings/WorkspaceSettingsView.swift
@@ -6,6 +6,7 @@ struct WorkspaceSettingsView: View {
     @Bindable var appState: AppState
     @State private var globalSettings = AppSettings()
     @State private var passthroughText = ""
+    @State private var overridePassthrough = false
     @State private var showRemoveAnthropicConfirm = false
     @State private var discoveredMCPServers: [String] = []
     @State private var overrideMCPServers = false
@@ -47,18 +48,29 @@ struct WorkspaceSettingsView: View {
                 )
             }
 
-            Section("Network Overrides") {
-                let defaultHint = globalSettings.passthroughHosts.isEmpty
-                    ? "No default passthrough hosts"
-                    : "Default: \(globalSettings.passthroughHosts.joined(separator: ", "))"
-                HostListEditor(
-                    caption: "Passthrough hosts override (\(defaultHint))",
-                    text: $passthroughText,
-                    missingHosts: passthroughOverrideMissingHosts,
-                    warningText: { joined in
-                        "This override would remove \(joined) from passthrough. Airlock would decrypt secrets in requests to Anthropic, sending your plaintext credentials to Anthropic's servers."
+            Section("Passthrough Override") {
+                Toggle("Override global passthrough", isOn: $overridePassthrough)
+                    .onChange(of: overridePassthrough) { _, newValue in
+                        if newValue && passthroughText.isEmpty {
+                            // Prefill from global when turning override on,
+                            // matching the network allow-list override pattern.
+                            passthroughText = globalSettings.passthroughHosts.joined(separator: "\n")
+                        }
                     }
-                )
+                if overridePassthrough {
+                    HostListEditor(
+                        caption: "Workspace passthrough hosts (one per line). Overrides global passthrough entirely.",
+                        text: $passthroughText,
+                        missingHosts: passthroughOverrideMissingHosts,
+                        warningText: { joined in
+                            "This override would remove \(joined) from passthrough. Airlock would decrypt secrets in requests to Anthropic, sending your plaintext credentials to Anthropic's servers."
+                        }
+                    )
+                } else {
+                    Text(inheritedPassthroughDescription)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
 
             Section("MCP Servers Override") {
@@ -152,14 +164,13 @@ struct WorkspaceSettingsView: View {
     }
 
     /// Protected hosts missing from the workspace passthrough override.
-    /// Returns an empty list when the editor is empty (empty = inherit
-    /// global, not an explicit removal), so the HostListEditor only
-    /// shows the warning for explicit non-empty overrides.
+    /// The override toggle gates this: when the toggle is OFF we return
+    /// an empty list (inherit is safe), but when ON we always check —
+    /// including the empty-editor case, which now means "explicitly no
+    /// passthrough for this workspace".
     private var passthroughOverrideMissingHosts: [String] {
+        guard overridePassthrough else { return [] }
         let parsed = PassthroughPolicy.splitHostLines(passthroughText)
-        if parsed.isEmpty {
-            return []
-        }
         return PassthroughPolicy.missingProtectedHosts(from: parsed)
     }
 
@@ -172,6 +183,13 @@ struct WorkspaceSettingsView: View {
         return "Inheriting global setting (all MCP servers enabled)."
     }
 
+    private var inheritedPassthroughDescription: String {
+        if globalSettings.passthroughHosts.isEmpty {
+            return "Inheriting global setting (no passthrough hosts — proxy decrypts all HTTPS)."
+        }
+        return "Inheriting global passthrough: \(globalSettings.passthroughHosts.joined(separator: ", "))."
+    }
+
     private var inheritedAllowlistDescription: String {
         if let global = globalSettings.networkAllowlist, !global.isEmpty {
             return "Inheriting global allow-list: \(global.joined(separator: ", "))."
@@ -181,7 +199,13 @@ struct WorkspaceSettingsView: View {
 
     private func load() {
         globalSettings = (try? WorkspaceStore().loadSettings()) ?? AppSettings()
-        passthroughText = workspace.passthroughHostsOverride?.joined(separator: "\n") ?? ""
+        if let override = workspace.passthroughHostsOverride {
+            overridePassthrough = true
+            passthroughText = override.joined(separator: "\n")
+        } else {
+            overridePassthrough = false
+            passthroughText = ""
+        }
         discoveredMCPServers = MCPInventoryService.discoverServerNames()
         if let override = workspace.enabledMCPServersOverride {
             overrideMCPServers = true
@@ -203,9 +227,13 @@ struct WorkspaceSettingsView: View {
         // Guardrails chain: passthrough → allow-list → commit. Each alert's
         // "confirm anyway" button re-enters this chain via the next helper
         // so users see BOTH warnings if they're both violated.
-        let hosts = PassthroughPolicy.splitHostLines(passthroughText)
-        // Empty override = inherit global; not flagged.
-        if !hosts.isEmpty {
+        //
+        // The override toggle gates the passthrough guardrail: OFF = inherit
+        // global (safe, no check). ON = check the editor contents, including
+        // the empty-editor case which now means "explicitly no passthrough
+        // for this workspace".
+        if overridePassthrough {
+            let hosts = PassthroughPolicy.splitHostLines(passthroughText)
             let missing = PassthroughPolicy.missingProtectedHosts(from: hosts)
             if !missing.isEmpty {
                 showRemoveAnthropicConfirm = true
@@ -228,7 +256,15 @@ struct WorkspaceSettingsView: View {
 
     private func commitSave(hosts: [String]) {
         if let idx = appState.workspaces.firstIndex(where: { $0.id == workspace.id }) {
-            appState.workspaces[idx].passthroughHostsOverride = hosts.isEmpty ? nil : hosts
+            if overridePassthrough {
+                // Explicit override — empty array means "no passthrough for
+                // this workspace" (not "inherit"). nil is only written when
+                // the toggle is OFF.
+                appState.workspaces[idx].passthroughHostsOverride =
+                    PassthroughPolicy.splitHostLines(passthroughText)
+            } else {
+                appState.workspaces[idx].passthroughHostsOverride = nil
+            }
             appState.workspaces[idx].enabledMCPServersOverride = overrideMCPServers
                 ? workspaceMCPSelection.sorted()
                 : nil

--- a/AirlockApp/Sources/AirlockApp/Views/Settings/WorkspaceSettingsView.swift
+++ b/AirlockApp/Sources/AirlockApp/Views/Settings/WorkspaceSettingsView.swift
@@ -17,22 +17,6 @@ struct WorkspaceSettingsView: View {
 
     var body: some View {
         Form {
-            Section("Secrets") {
-                HStack {
-                    Text("Manage secret files in the Secrets tab (Cmd+2)")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    Spacer()
-                }
-                if let envPath = workspace.envFilePath {
-                    HStack {
-                        Text("Legacy .env: \((envPath as NSString).lastPathComponent)")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-            }
-
             Section("Container Overrides") {
                 TextField(
                     "Container image (\(globalSettings.containerImage))",

--- a/AirlockApp/Sources/AirlockApp/Views/Settings/WorkspaceSettingsView.swift
+++ b/AirlockApp/Sources/AirlockApp/Views/Settings/WorkspaceSettingsView.swift
@@ -137,7 +137,7 @@ struct WorkspaceSettingsView: View {
         .alert("Allow-list blocks Anthropic in this workspace?", isPresented: $showAllowlistAnthropicConfirm) {
             Button("Cancel", role: .cancel) {}
             Button("Save anyway", role: .destructive) {
-                commitSave(hosts: PassthroughPolicy.splitHostLines(passthroughText))
+                commitSave()
             }
         } message: {
             let missing = NetworkAllowlistPolicy.missingProtectedHosts(
@@ -235,10 +235,10 @@ struct WorkspaceSettingsView: View {
                 return
             }
         }
-        commitSave(hosts: PassthroughPolicy.splitHostLines(passthroughText))
+        commitSave()
     }
 
-    private func commitSave(hosts: [String]) {
+    private func commitSave() {
         if let idx = appState.workspaces.firstIndex(where: { $0.id == workspace.id }) {
             if overridePassthrough {
                 // Explicit override — empty array means "no passthrough for

--- a/AirlockApp/Sources/AirlockApp/Views/Sidebar/NewWorkspaceSheet.swift
+++ b/AirlockApp/Sources/AirlockApp/Views/Sidebar/NewWorkspaceSheet.swift
@@ -13,7 +13,6 @@ struct NewWorkspaceSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.containerService) private var containerService
     @State private var selectedPath: String = ""
-    @State private var envFilePath: String = ""
     @State private var statusMessage: String = ""
     @State private var isProcessing = false
     @State private var checks: [PreCheck] = []
@@ -28,19 +27,6 @@ struct NewWorkspaceSheet: View {
                 TextField("Project directory", text: $selectedPath)
                     .textFieldStyle(.roundedBorder)
                 Button("Browse...") { pickDirectory() }
-            }
-
-            HStack {
-                TextField(".env file (optional)", text: $envFilePath)
-                    .textFieldStyle(.roundedBorder)
-                Button("Browse...") { pickEnvFile() }
-                if !envFilePath.isEmpty {
-                    Button { envFilePath = "" } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                }
             }
 
             if !checks.isEmpty {
@@ -65,7 +51,6 @@ struct NewWorkspaceSheet: View {
         .padding()
         .frame(width: 500)
         .onChange(of: selectedPath) { _, _ in Task { await runPreChecks() } }
-        .onChange(of: envFilePath) { _, _ in Task { await runPreChecks() } }
     }
 
     private var preCheckList: some View {
@@ -124,28 +109,6 @@ struct NewWorkspaceSheet: View {
             detail: initialized ? nil : "will run airlock init"
         ))
 
-        if !envFilePath.isEmpty {
-            let envContent = (try? String(contentsOfFile: envFilePath, encoding: .utf8)) ?? ""
-            let sensitivePatterns = ["KEY", "SECRET", "PASSWORD", "TOKEN"]
-            let hasPlaintext = envContent
-                .components(separatedBy: .newlines)
-                .contains { line in
-                    let parts = line.split(separator: "=", maxSplits: 1)
-                    guard parts.count == 2 else { return false }
-                    let key = String(parts[0]).uppercased()
-                    let value = String(parts[1])
-                    return sensitivePatterns.contains(where: { key.contains($0) }) && !value.hasPrefix("ENC[age:")
-                }
-            if hasPlaintext {
-                results.append(PreCheck(
-                    id: "secrets",
-                    label: "Plaintext secrets detected",
-                    passed: false,
-                    detail: "will be encrypted on activation"
-                ))
-            }
-        }
-
         // Show synchronous checks immediately, Docker check updates async
         results.append(PreCheck(
             id: "docker",
@@ -171,16 +134,6 @@ struct NewWorkspaceSheet: View {
         }
     }
 
-    private func pickEnvFile() {
-        let panel = NSOpenPanel()
-        panel.canChooseDirectories = false
-        panel.canChooseFiles = true
-        panel.allowsMultipleSelection = false
-        if panel.runModal() == .OK, let url = panel.url {
-            envFilePath = url.path
-        }
-    }
-
     private func addWorkspace() {
         isProcessing = true
         let cli = CLIService()
@@ -202,8 +155,7 @@ struct NewWorkspaceSheet: View {
             let name = URL(filePath: path).lastPathComponent
             let workspace = Workspace(
                 name: name,
-                path: path,
-                envFilePath: envFilePath.isEmpty ? nil : envFilePath
+                path: path
             )
             appState.workspaces.append(workspace)
             appState.selectedWorkspaceID = workspace.id

--- a/AirlockApp/Tests/AirlockAppTests/AppStateTests.swift
+++ b/AirlockApp/Tests/AirlockAppTests/AppStateTests.swift
@@ -325,4 +325,23 @@ final class AppStateTests: XCTestCase {
         XCTAssertNil(decoded.passthroughHostsDraft)
         XCTAssertEqual(decoded.passthroughHosts, ["api.anthropic.com", "auth.anthropic.com"])
     }
+
+    func testLegacyEmptyPassthroughHostsWithoutDraftDecodes() throws {
+        // Upgrade path from the pre-7390166 installs referenced in ADR-0010:
+        // settings.json has `passthroughHosts: []` and no `passthroughHostsDraft`
+        // key at all. The new toggle-driven load() should treat this as
+        // "toggle OFF, draft nil, editor empty" without crashing.
+        let legacyJSON = """
+        {
+          "containerImage": "airlock-claude:latest",
+          "proxyImage": "airlock-proxy:latest",
+          "passthroughHosts": [],
+          "theme": "System",
+          "terminal": { "fontName": "Menlo", "fontSize": 12 }
+        }
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: legacyJSON)
+        XCTAssertEqual(decoded.passthroughHosts, [])
+        XCTAssertNil(decoded.passthroughHostsDraft)
+    }
 }

--- a/AirlockApp/Tests/AirlockAppTests/AppStateTests.swift
+++ b/AirlockApp/Tests/AirlockAppTests/AppStateTests.swift
@@ -122,6 +122,19 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(resolved.networkAllowlist, [])
     }
 
+    func testEmptyPassthroughOverrideResolvesToEmptyArray() {
+        // An explicit empty-array passthrough override means "no passthrough
+        // for this workspace" and must win over a populated global setting.
+        // This is the load-bearing distinction that the Passthrough Override
+        // toggle exposes in the workspace settings UI.
+        var global = AppSettings()
+        global.passthroughHosts = ["api.anthropic.com", "auth.anthropic.com"]
+        var ws = Workspace(name: "test", path: "/tmp")
+        ws.passthroughHostsOverride = []
+        let resolved = ResolvedSettings(global: global, workspace: ws)
+        XCTAssertEqual(resolved.passthroughHosts, [])
+    }
+
     func testResolvedSettingsNilMCPMeansAllEnabled() {
         // Both global and workspace nil => nil (meaning: do not filter, keep all MCPs)
         let global = AppSettings()

--- a/AirlockApp/Tests/AirlockAppTests/AppStateTests.swift
+++ b/AirlockApp/Tests/AirlockAppTests/AppStateTests.swift
@@ -278,4 +278,38 @@ final class AppStateTests: XCTestCase {
         // ws2 unaffected
         XCTAssertEqual(state.activationState(for: ws2), .active)
     }
+
+    // MARK: - passthroughHostsDraft round-trip
+
+    func testPassthroughHostsDraftDefaultsToNil() {
+        let settings = AppSettings()
+        XCTAssertNil(settings.passthroughHostsDraft)
+    }
+
+    func testPassthroughHostsDraftEncodeDecodeRoundTrip() throws {
+        var settings = AppSettings()
+        settings.passthroughHosts = []
+        settings.passthroughHostsDraft = ["api.anthropic.com", "auth.anthropic.com"]
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: data)
+        XCTAssertEqual(decoded.passthroughHosts, [])
+        XCTAssertEqual(decoded.passthroughHostsDraft, ["api.anthropic.com", "auth.anthropic.com"])
+    }
+
+    func testPassthroughHostsDraftMissingKeyDecodesAsNil() throws {
+        // Simulate a settings.json written by the previous app version:
+        // no passthroughHostsDraft key at all.
+        let legacyJSON = """
+        {
+          "containerImage": "airlock-claude:latest",
+          "proxyImage": "airlock-proxy:latest",
+          "passthroughHosts": ["api.anthropic.com", "auth.anthropic.com"],
+          "theme": "System",
+          "terminal": { "fontName": "Menlo", "fontSize": 12 }
+        }
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: legacyJSON)
+        XCTAssertNil(decoded.passthroughHostsDraft)
+        XCTAssertEqual(decoded.passthroughHosts, ["api.anthropic.com", "auth.anthropic.com"])
+    }
 }

--- a/AirlockApp/Tests/AirlockAppTests/WorkspaceTests.swift
+++ b/AirlockApp/Tests/AirlockAppTests/WorkspaceTests.swift
@@ -74,6 +74,18 @@ final class WorkspaceTests: XCTestCase {
         XCTAssertEqual(decoded.enabledMCPServersOverride, [])
     }
 
+    func testEmptyPassthroughOverridePersisted() throws {
+        // Empty array is a valid explicit override ("no passthrough for
+        // this workspace"), distinct from nil (inherit global). The
+        // workspace settings toggle exposes this difference directly.
+        var ws = Workspace(name: "test", path: "/tmp")
+        ws.passthroughHostsOverride = []
+        let data = try JSONEncoder().encode(ws)
+        let decoded = try JSONDecoder().decode(Workspace.self, from: data)
+        XCTAssertNotNil(decoded.passthroughHostsOverride)
+        XCTAssertEqual(decoded.passthroughHostsOverride, [])
+    }
+
     func testBackwardsCompatDecoding() throws {
         // Simulate old workspaces.json without new fields
         let json = """

--- a/docs/decisions/ADR-0010-environment-variable-secrets.md
+++ b/docs/decisions/ADR-0010-environment-variable-secrets.md
@@ -74,7 +74,8 @@ Rejected. Testing legitimately requires removing Anthropic from passthrough some
 
 Installs that existed before commit `7390166` (2026-04-03) have `"passthroughHosts":[]` persisted in `~/Library/Application Support/Airlock/settings.json`. The Swift `AppSettings.init(from:)` decoder uses `decodeIfPresent` which only substitutes the `["api.anthropic.com", "auth.anthropic.com"]` default when the key is **absent**, not when it is **present but empty**. A user upgrading across this release will therefore start with a global passthrough list of `[]`, which means:
 
-- The workspace Settings tab shows `Passthrough hosts override (No default passthrough hosts)` instead of the expected `Default: api.anthropic.com, auth.anthropic.com`.
+- The Global Settings `Passthrough Hosts` section loads with the `Enable passthrough hosts` toggle OFF and an empty editor, instead of the expected toggle-ON + pre-populated Anthropic host list.
+- The workspace Settings tab's `Passthrough Override` section shows the caption `Inheriting global setting (no passthrough hosts — proxy decrypts all HTTPS).` instead of `Inheriting global passthrough: api.anthropic.com, auth.anthropic.com.`
 - Every workspace with `passthroughHostsOverride == nil` inherits the empty global list at session start.
 - The Secrets tab banner from this ADR's guardrail correctly fires in this state (`⚠ Anthropic passthrough disabled — secrets will be sent as plaintext to api.anthropic.com, auth.anthropic.com`), surfacing the issue to the user.
 

--- a/docs/decisions/ADR-0010-environment-variable-secrets.md
+++ b/docs/decisions/ADR-0010-environment-variable-secrets.md
@@ -80,7 +80,7 @@ Installs that existed before commit `7390166` (2026-04-03) have `"passthroughHos
 
 **Decision: ship as-is.** No users were upgrading across this release (the project had not distributed the pre-`7390166` version yet). The guardrail banner is the safety net. An auto-heal in the decoder (treat empty array as absent) was considered and rejected because it would silently undo a user's future intentional decision to empty the list.
 
-**Fix for affected users:** Open global Settings, add `api.anthropic.com` and `auth.anthropic.com` to the Network Defaults editor, click Save. Verified manually in Scenario 1 of the manual test runbook.
+**Fix for affected users:** Open global Settings, turn on `Enable passthrough hosts` in the `Passthrough Hosts` section, ensure `api.anthropic.com` and `auth.anthropic.com` are in the editor, click Save. Verified manually in Scenario 1 of the manual test runbook.
 
 ## Future Considerations
 

--- a/docs/guides/security-model.md
+++ b/docs/guides/security-model.md
@@ -68,8 +68,8 @@ A mitmproxy sidecar intercepts outbound HTTP/HTTPS traffic from the agent contai
 
 **Two Settings layers:** The GUI has two distinct places to edit passthrough hosts and they operate at different scopes.
 
-- **Global Settings** (gear icon in the sidebar, or `Airlock → Settings...` menu) is the install-wide default, persisted in `~/Library/Application Support/Airlock/settings.json`. The `Network Defaults` editor here seeds the fall-through value for every workspace that has no per-workspace override.
-- **Workspace Settings tab** (Cmd+4 on a selected workspace) is per-workspace, persisted in that workspace's entry in `workspaces.json`. The `Network Overrides` editor here is OPTIONAL — an empty editor means "inherit global," a non-empty editor means "use this exact list for this workspace instead." The caption line reminds the user of the current global value.
+- **Global Settings** (gear icon in the sidebar, or `Airlock → Settings...` menu) is the install-wide default, persisted in `~/Library/Application Support/Airlock/settings.json`. The `Passthrough Hosts` section here seeds the fall-through value for every workspace that has no per-workspace override. The section has an `Enable passthrough hosts` toggle: when OFF the stored list is empty (proxy decrypts all HTTPS, including Anthropic), and the editor text is preserved as a draft so the user can re-enable it later.
+- **Workspace Settings tab** (Cmd+4 on a selected workspace) is per-workspace, persisted in that workspace's entry in `workspaces.json`. The `Passthrough Override` section has an `Override global passthrough` toggle: when OFF the workspace inherits the global list; when ON with content the editor text is used; when ON with an empty editor passthrough is explicitly disabled for this workspace (distinct from inherit).
 
 At session start, `ResolvedSettings.passthroughHosts = workspace.passthroughHostsOverride ?? global.passthroughHosts`. This two-layer model is subtle; if you are editing passthrough and not seeing the change take effect, confirm whether you are editing the global defaults or the workspace override.
 

--- a/docs/superpowers/plans/2026-04-07-env-secrets-and-passthrough-guardrail-manual-test.md
+++ b/docs/superpowers/plans/2026-04-07-env-secrets-and-passthrough-guardrail-manual-test.md
@@ -42,15 +42,17 @@ All three are pass/fail on a single log line or HTTP response. If any step devia
 - [ ] **1.4** Choose a scratch directory, e.g., `mkdir -p /tmp/airlock-test-scenario-1 && pick that`.
 - [ ] **1.5** Select the new workspace in the sidebar. Do NOT click "Activate" yet.
 - [ ] **1.6** Switch to the **Settings** tab (Cmd+4) for this workspace.
-- [ ] **1.7** Find the "Network Overrides" section. **Expected:**
-    - Caption reads `Default: api.anthropic.com, auth.anthropic.com`
-    - The override `TextEditor` is EMPTY (empty override = inherit global)
-    - NO yellow inline warning row below the editor
+- [ ] **1.7** Find the "Passthrough Override" section. **Expected:**
+    - `Override global passthrough` toggle is OFF
+    - Caption reads `Inheriting global passthrough: api.anthropic.com, auth.anthropic.com.`
+    - No override `TextEditor` is visible (hidden while toggle is OFF)
+    - NO yellow inline warning row
 - [ ] **1.8** Switch to the **Secrets** tab (Cmd+2) for this workspace. **Expected:**
     - NO yellow "⚠ Anthropic passthrough disabled" banner at the top of the view
     - The "Env Variables" sidebar section is visible and empty
 - [ ] **1.9** Open global Settings (gear icon / menu `Airlock → Settings...`).
-- [ ] **1.10** Find the "Network Defaults" section. **Expected:**
+- [ ] **1.10** Find the "Passthrough Hosts" section. **Expected:**
+    - `Enable passthrough hosts` toggle is ON
     - The `TextEditor` contains TWO lines: `api.anthropic.com` and `auth.anthropic.com`
     - NO yellow inline warning row below the editor
 - [ ] **1.11** Close the Settings sheet with Cancel (do not save).

--- a/docs/superpowers/plans/2026-04-08-network-allowlist-manual-test.md
+++ b/docs/superpowers/plans/2026-04-08-network-allowlist-manual-test.md
@@ -361,7 +361,7 @@ Three equivalent entry points (pick any):
 2. Terminal (font + size)
 3. General (airlock binary path)
 4. Container Defaults
-5. Network Defaults (passthrough hosts)
+5. Passthrough Hosts (toggle + editor)
 6. MCP Servers
 7. **Network Allow-list** ← scenario 6's target
 8. Claude Code State Volume
@@ -494,7 +494,7 @@ This is the critical UX regression fix from the code review.
 ### Subscenario 7a — Chained guardrails (no session activation needed)
 
 - [ ] **7a.1** Select the workspace in the sidebar, switch to the **Settings** tab (Cmd+4).
-- [ ] **7a.2** In "Network Overrides", type a passthrough override that does NOT include Anthropic:
+- [ ] **7a.2** In "Passthrough Override", turn the `Override global passthrough` toggle ON. The editor appears prefilled with the global host list. Clear it, then type a passthrough override that does NOT include Anthropic:
     ```
     api.github.com
     ```
@@ -509,7 +509,7 @@ This is the critical UX regression fix from the code review.
     - **Second alert** (immediately after dismissing the first): `Allow-list blocks Anthropic in this workspace?` — title mentions allow-list. This alert MUST appear. If it does not, the guardrail-chaining fix has regressed — STOP and investigate.
     - Click `Cancel` on the second alert. Neither override is saved.
 - [ ] **7a.5** Verify persistence: reopen the tab. The two TextEditors should still show the in-progress drafts (not yet persisted). The workspace's `workspaces.json` entry should NOT contain `passthroughHostsOverride` or `networkAllowlistOverride`.
-- [ ] **7a.6** Clear both editors (delete all text in both), click **Save**. **Expected:** No alerts, sheet closes. The workspace now falls back to global settings for both.
+- [ ] **7a.6** Turn BOTH override toggles OFF (`Override global passthrough` AND `Override global allow-list`). The editors disappear and the captions read "Inheriting ...". Click **Save**. **Expected:** No alerts, the workspace now inherits global settings for both.
 
 ### Subscenario 7b — End-to-end: allow-list-restricted workspace runs Claude Code
 

--- a/docs/superpowers/plans/2026-04-09-gui-minor-fixes.md
+++ b/docs/superpowers/plans/2026-04-09-gui-minor-fixes.md
@@ -1,0 +1,935 @@
+# GUI Minor Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add on/off toggles and clearer headers to the passthrough sections in global and workspace settings, remove the legacy `.env file` flow from the New Workspace sheet, and delete the now-redundant "Secrets" section from workspace settings.
+
+**Architecture:** Four independent UI changes in the SwiftUI app. A new `passthroughHostsDraft: [String]?` field on `AppSettings` persists the toggled-OFF editor text across app restarts. Workspace-level passthrough override semantics change: `nil` = inherit, empty array `[]` = explicit "no passthrough hosts for this workspace". Existing `Workspace.envFilePath` model field and CLI `--env` plumbing stay intact so existing workspaces keep activating.
+
+**Tech Stack:** Swift 5.9+, SwiftUI, XCTest. Built via `make gui-build` / `make gui-test`. Runs on macOS 14+.
+
+**Spec:** `docs/superpowers/specs/2026-04-09-gui-minor-fixes-design.md`
+
+---
+
+## File Structure
+
+Files that will be created or modified:
+
+| File | Role | Change |
+|---|---|---|
+| `AirlockApp/Sources/AirlockApp/Models/AppState.swift` | `AppSettings` struct definition | Add `passthroughHostsDraft: [String]?` field + Codable handling |
+| `AirlockApp/Tests/AirlockAppTests/AppStateTests.swift` | `AppSettings` tests | Add round-trip tests for the new field |
+| `AirlockApp/Sources/AirlockApp/Views/Settings/SettingsView.swift` | Global settings sheet | Rename section, add toggle, load/save draft |
+| `AirlockApp/Sources/AirlockApp/Views/Settings/WorkspaceSettingsView.swift` | Workspace settings sheet | Rename passthrough section, add toggle, delete Secrets section, change empty-override semantics |
+| `AirlockApp/Sources/AirlockApp/Views/Sidebar/NewWorkspaceSheet.swift` | New workspace sheet | Remove `.env file` TextField, state, pre-check, picker |
+
+All five files are modifications. No new files. No file splits (all affected files are under the 800-line ceiling).
+
+---
+
+## Task 1: Add `passthroughHostsDraft` field to `AppSettings`
+
+**Files:**
+- Modify: `AirlockApp/Sources/AirlockApp/Models/AppState.swift:179-202`
+- Test: `AirlockApp/Tests/AirlockAppTests/AppStateTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Append at the end of `AirlockApp/Tests/AirlockAppTests/AppStateTests.swift`, just before the closing brace of `final class AppStateTests`:
+
+```swift
+    // MARK: - passthroughHostsDraft round-trip
+
+    func testPassthroughHostsDraftDefaultsToNil() {
+        let settings = AppSettings()
+        XCTAssertNil(settings.passthroughHostsDraft)
+    }
+
+    func testPassthroughHostsDraftEncodeDecodeRoundTrip() throws {
+        var settings = AppSettings()
+        settings.passthroughHosts = []
+        settings.passthroughHostsDraft = ["api.anthropic.com", "auth.anthropic.com"]
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: data)
+        XCTAssertEqual(decoded.passthroughHosts, [])
+        XCTAssertEqual(decoded.passthroughHostsDraft, ["api.anthropic.com", "auth.anthropic.com"])
+    }
+
+    func testPassthroughHostsDraftMissingKeyDecodesAsNil() throws {
+        // Simulate a settings.json written by the previous app version:
+        // no passthroughHostsDraft key at all.
+        let legacyJSON = """
+        {
+          "containerImage": "airlock-claude:latest",
+          "proxyImage": "airlock-proxy:latest",
+          "passthroughHosts": ["api.anthropic.com", "auth.anthropic.com"],
+          "theme": "system",
+          "terminal": { "fontName": "Menlo", "fontSize": 12 }
+        }
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: legacyJSON)
+        XCTAssertNil(decoded.passthroughHostsDraft)
+        XCTAssertEqual(decoded.passthroughHosts, ["api.anthropic.com", "auth.anthropic.com"])
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make gui-test`
+
+Expected: Build error — `AppSettings has no member 'passthroughHostsDraft'`.
+
+- [ ] **Step 3: Add the field to `AppSettings`**
+
+In `AirlockApp/Sources/AirlockApp/Models/AppState.swift`, find the `struct AppSettings: Codable, Equatable { ... }` block starting at line 179 and add the new field plus one decode line.
+
+Change lines 179–202 from:
+
+```swift
+struct AppSettings: Codable, Equatable {
+    var airlockBinaryPath: String?
+    var containerImage: String = "airlock-claude:latest"
+    var proxyImage: String = "airlock-proxy:latest"
+    var passthroughHosts: [String] = ["api.anthropic.com", "auth.anthropic.com"]
+    var enabledMCPServers: [String]?
+    var networkAllowlist: [String]?
+    var theme: AppTheme = .system
+    var terminal: TerminalSettings = TerminalSettings()
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        airlockBinaryPath = try container.decodeIfPresent(String.self, forKey: .airlockBinaryPath)
+        containerImage = try container.decodeIfPresent(String.self, forKey: .containerImage) ?? "airlock-claude:latest"
+        proxyImage = try container.decodeIfPresent(String.self, forKey: .proxyImage) ?? "airlock-proxy:latest"
+        passthroughHosts = try container.decodeIfPresent([String].self, forKey: .passthroughHosts) ?? ["api.anthropic.com", "auth.anthropic.com"]
+        enabledMCPServers = try container.decodeIfPresent([String].self, forKey: .enabledMCPServers)
+        networkAllowlist = try container.decodeIfPresent([String].self, forKey: .networkAllowlist)
+        theme = try container.decodeIfPresent(AppTheme.self, forKey: .theme) ?? .system
+        terminal = try container.decodeIfPresent(TerminalSettings.self, forKey: .terminal) ?? TerminalSettings()
+    }
+}
+```
+
+to:
+
+```swift
+struct AppSettings: Codable, Equatable {
+    var airlockBinaryPath: String?
+    var containerImage: String = "airlock-claude:latest"
+    var proxyImage: String = "airlock-proxy:latest"
+    var passthroughHosts: [String] = ["api.anthropic.com", "auth.anthropic.com"]
+    /// Editor text to restore when the global passthrough toggle is OFF.
+    /// Never read by the CLI layer; used only by `SettingsView` to preserve
+    /// the user's in-progress host list across app restarts while the
+    /// toggle is disabled. Nil when the toggle is ON.
+    var passthroughHostsDraft: [String]?
+    var enabledMCPServers: [String]?
+    var networkAllowlist: [String]?
+    var theme: AppTheme = .system
+    var terminal: TerminalSettings = TerminalSettings()
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        airlockBinaryPath = try container.decodeIfPresent(String.self, forKey: .airlockBinaryPath)
+        containerImage = try container.decodeIfPresent(String.self, forKey: .containerImage) ?? "airlock-claude:latest"
+        proxyImage = try container.decodeIfPresent(String.self, forKey: .proxyImage) ?? "airlock-proxy:latest"
+        passthroughHosts = try container.decodeIfPresent([String].self, forKey: .passthroughHosts) ?? ["api.anthropic.com", "auth.anthropic.com"]
+        passthroughHostsDraft = try container.decodeIfPresent([String].self, forKey: .passthroughHostsDraft)
+        enabledMCPServers = try container.decodeIfPresent([String].self, forKey: .enabledMCPServers)
+        networkAllowlist = try container.decodeIfPresent([String].self, forKey: .networkAllowlist)
+        theme = try container.decodeIfPresent(AppTheme.self, forKey: .theme) ?? .system
+        terminal = try container.decodeIfPresent(TerminalSettings.self, forKey: .terminal) ?? TerminalSettings()
+    }
+}
+```
+
+Swift auto-synthesizes `CodingKeys` to include every stored property, so adding the field alone is enough — no explicit `CodingKeys` enum change is needed.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `make gui-test`
+
+Expected: All AppState tests pass, including the three new `passthroughHostsDraft` tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add AirlockApp/Sources/AirlockApp/Models/AppState.swift AirlockApp/Tests/AirlockAppTests/AppStateTests.swift
+git commit -m "feat: add passthroughHostsDraft field to AppSettings"
+```
+
+---
+
+## Task 2: Rename global settings section and add passthrough toggle
+
+**Files:**
+- Modify: `AirlockApp/Sources/AirlockApp/Views/Settings/SettingsView.swift`
+
+Goal: rename `Section("Network Defaults")` → `Section("Passthrough Hosts")`, introduce a toggle that controls editor visibility and write path, and persist/restore the editor text via `passthroughHostsDraft` when the toggle is OFF.
+
+- [ ] **Step 1: Add the toggle state property**
+
+In `AirlockApp/Sources/AirlockApp/Views/Settings/SettingsView.swift`, find the `@State` declarations at the top of `GlobalSettingsSheet` (lines 6–19). Add one new `@State` line after the existing `@State private var passthroughText = ""` line so the block reads:
+
+```swift
+    @Bindable var appState: AppState
+    @Environment(\.dismiss) private var dismiss
+    @State private var settings = AppSettings()
+    @State private var passthroughText = ""
+    @State private var enablePassthrough = true
+    @State private var saved = false
+    @State private var volumeStatus = "Checking..."
+    @State private var showImportSheet = false
+    @State private var showResetAlert = false
+    @State private var showRemoveAnthropicConfirm = false
+    @State private var discoveredMCPServers: [String] = []
+    @State private var restrictMCPServers = false
+    @State private var enabledMCPSelection: Set<String> = []
+    @State private var restrictNetworkAllowlist = false
+    @State private var networkAllowlistText = ""
+    @State private var showAllowlistAnthropicConfirm = false
+```
+
+- [ ] **Step 2: Rewrite the "Network Defaults" section**
+
+Find the section block at lines 70–81:
+
+```swift
+                Section("Network Defaults") {
+                    HostListEditor(
+                        caption: "Default passthrough hosts (skip proxy decryption, one per line)",
+                        text: $passthroughText,
+                        missingHosts: PassthroughPolicy.missingProtectedHosts(
+                            from: PassthroughPolicy.splitHostLines(passthroughText)
+                        ),
+                        warningText: { joined in
+                            "Removing \(joined) from passthrough means Airlock will decrypt secrets in requests to Anthropic. Your plaintext credentials will be sent to Anthropic's servers. This defeats the purpose of Airlock — only remove for testing."
+                        }
+                    )
+                }
+```
+
+Replace it with:
+
+```swift
+                Section("Passthrough Hosts") {
+                    Toggle("Enable passthrough hosts", isOn: $enablePassthrough)
+                    if enablePassthrough {
+                        HostListEditor(
+                            caption: "Passthrough hosts skip proxy decryption (one per line). Anthropic endpoints belong here so credentials stay encrypted in transit.",
+                            text: $passthroughText,
+                            missingHosts: PassthroughPolicy.missingProtectedHosts(
+                                from: PassthroughPolicy.splitHostLines(passthroughText)
+                            ),
+                            warningText: { joined in
+                                "Removing \(joined) from passthrough means Airlock will decrypt secrets in requests to Anthropic. Your plaintext credentials will be sent to Anthropic's servers. This defeats the purpose of Airlock — only remove for testing."
+                            }
+                        )
+                    } else {
+                        Text("All outbound HTTPS, including Anthropic, will flow through the proxy for secret decryption. Your plaintext credentials will be sent to Anthropic's servers.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+```
+
+- [ ] **Step 3: Update `load()` to restore the toggle and draft**
+
+Find `private func load()` at lines 211–230. Replace the first four body lines:
+
+```swift
+    private func load() {
+        let store = WorkspaceStore()
+        settings = (try? store.loadSettings()) ?? AppSettings()
+        passthroughText = settings.passthroughHosts.joined(separator: "\n")
+        discoveredMCPServers = MCPInventoryService.discoverServerNames()
+```
+
+with:
+
+```swift
+    private func load() {
+        let store = WorkspaceStore()
+        settings = (try? store.loadSettings()) ?? AppSettings()
+        if settings.passthroughHosts.isEmpty {
+            // Toggle OFF state — show the persisted draft (if any) so the
+            // user sees whatever they were working on before they turned
+            // passthrough off. Nil draft => empty editor.
+            enablePassthrough = false
+            passthroughText = (settings.passthroughHostsDraft ?? []).joined(separator: "\n")
+        } else {
+            enablePassthrough = true
+            passthroughText = settings.passthroughHosts.joined(separator: "\n")
+        }
+        discoveredMCPServers = MCPInventoryService.discoverServerNames()
+```
+
+The rest of `load()` (MCP and network-allowlist branches) stays unchanged.
+
+- [ ] **Step 4: Update `save()` to branch on the toggle**
+
+Find `private func save()` at lines 232–244:
+
+```swift
+    private func save() {
+        // Guardrails chain: passthrough → allow-list → commit. Each alert's
+        // "confirm anyway" button re-enters this chain via the next helper
+        // so users see BOTH warnings if they're both violated, instead of
+        // silently losing the second alert after confirming the first.
+        let parsed = PassthroughPolicy.splitHostLines(passthroughText)
+        let missing = PassthroughPolicy.missingProtectedHosts(from: parsed)
+        if !missing.isEmpty {
+            showRemoveAnthropicConfirm = true
+            return
+        }
+        proceedAfterPassthroughConfirmed()
+    }
+```
+
+Replace with:
+
+```swift
+    private func save() {
+        // Guardrails chain: passthrough → allow-list → commit. Each alert's
+        // "confirm anyway" button re-enters this chain via the next helper
+        // so users see BOTH warnings if they're both violated, instead of
+        // silently losing the second alert after confirming the first.
+        //
+        // When the passthrough toggle is OFF, the stored host list is []
+        // (meaning proxy decrypts everything). missingProtectedHosts([])
+        // returns the full protected set, so the guardrail still fires —
+        // disabling passthrough is always a confirmed action.
+        let parsed = enablePassthrough
+            ? PassthroughPolicy.splitHostLines(passthroughText)
+            : []
+        let missing = PassthroughPolicy.missingProtectedHosts(from: parsed)
+        if !missing.isEmpty {
+            showRemoveAnthropicConfirm = true
+            return
+        }
+        proceedAfterPassthroughConfirmed()
+    }
+```
+
+- [ ] **Step 5: Update `commitSave()` to write `passthroughHosts` and `passthroughHostsDraft`**
+
+Find `private func commitSave(hosts: [String])` at lines 257–281. Replace the first block that currently reads:
+
+```swift
+    private func commitSave(hosts: [String]) {
+        settings.passthroughHosts = hosts
+        settings.enabledMCPServers = restrictMCPServers
+```
+
+with:
+
+```swift
+    private func commitSave(hosts: [String]) {
+        if enablePassthrough {
+            settings.passthroughHosts = hosts
+            settings.passthroughHostsDraft = nil
+        } else {
+            settings.passthroughHosts = []
+            // Preserve whatever is currently in the editor so the user can
+            // flip the toggle back ON later and see their previous list.
+            let draft = PassthroughPolicy.splitHostLines(passthroughText)
+            settings.passthroughHostsDraft = draft.isEmpty ? nil : draft
+        }
+        settings.enabledMCPServers = restrictMCPServers
+```
+
+The rest of `commitSave()` (MCP + network allow-list + persist) stays unchanged.
+
+Also find `proceedAfterPassthroughConfirmed()` at lines 246–255. The final line is:
+
+```swift
+        commitSave(hosts: PassthroughPolicy.splitHostLines(passthroughText))
+```
+
+Change it to:
+
+```swift
+        commitSave(hosts: enablePassthrough ? PassthroughPolicy.splitHostLines(passthroughText) : [])
+```
+
+And the identical line inside the `showAllowlistAnthropicConfirm` alert block at lines 188–192 — the `"Save anyway"` button body:
+
+```swift
+            Button("Save anyway", role: .destructive) {
+                commitSave(hosts: PassthroughPolicy.splitHostLines(passthroughText))
+            }
+```
+
+becomes:
+
+```swift
+            Button("Save anyway", role: .destructive) {
+                commitSave(hosts: enablePassthrough ? PassthroughPolicy.splitHostLines(passthroughText) : [])
+            }
+```
+
+- [ ] **Step 6: Build the GUI to verify the changes compile**
+
+Run: `make gui-build`
+
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 7: Run tests**
+
+Run: `make gui-test`
+
+Expected: All tests pass. No new tests for this task — it is a view-layer change; behavior is verified through the `AppSettings` round-trip tests from Task 1 and manual testing.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add AirlockApp/Sources/AirlockApp/Views/Settings/SettingsView.swift
+git commit -m "feat: add passthrough hosts toggle to global settings"
+```
+
+---
+
+## Task 3: Rename workspace passthrough section and add override toggle
+
+**Files:**
+- Modify: `AirlockApp/Sources/AirlockApp/Views/Settings/WorkspaceSettingsView.swift`
+
+Goal: rename `Section("Network Overrides")` → `Section("Passthrough Override")`, add an override toggle whose OFF state inherits global passthrough, and change the empty-editor semantics so that `toggle ON + empty editor = explicit "[]"` (no longer "inherit").
+
+- [ ] **Step 1: Add new state properties**
+
+In `AirlockApp/Sources/AirlockApp/Views/Settings/WorkspaceSettingsView.swift`, find the `@State` block at lines 7–15. Add `overridePassthrough` after `passthroughText`:
+
+```swift
+    @State private var globalSettings = AppSettings()
+    @State private var passthroughText = ""
+    @State private var overridePassthrough = false
+    @State private var showRemoveAnthropicConfirm = false
+    @State private var discoveredMCPServers: [String] = []
+    @State private var overrideMCPServers = false
+    @State private var workspaceMCPSelection: Set<String> = []
+    @State private var overrideNetworkAllowlist = false
+    @State private var networkAllowlistText = ""
+    @State private var showAllowlistAnthropicConfirm = false
+```
+
+- [ ] **Step 2: Rewrite the passthrough section**
+
+Find the section block at lines 50–62:
+
+```swift
+            Section("Network Overrides") {
+                let defaultHint = globalSettings.passthroughHosts.isEmpty
+                    ? "No default passthrough hosts"
+                    : "Default: \(globalSettings.passthroughHosts.joined(separator: ", "))"
+                HostListEditor(
+                    caption: "Passthrough hosts override (\(defaultHint))",
+                    text: $passthroughText,
+                    missingHosts: passthroughOverrideMissingHosts,
+                    warningText: { joined in
+                        "This override would remove \(joined) from passthrough. Airlock would decrypt secrets in requests to Anthropic, sending your plaintext credentials to Anthropic's servers."
+                    }
+                )
+            }
+```
+
+Replace with:
+
+```swift
+            Section("Passthrough Override") {
+                Toggle("Override global passthrough", isOn: $overridePassthrough)
+                    .onChange(of: overridePassthrough) { _, newValue in
+                        if newValue && passthroughText.isEmpty {
+                            // Prefill from global when turning override on,
+                            // matching the network allow-list override pattern.
+                            passthroughText = globalSettings.passthroughHosts.joined(separator: "\n")
+                        }
+                    }
+                if overridePassthrough {
+                    HostListEditor(
+                        caption: "Workspace passthrough hosts (one per line). Overrides global passthrough entirely.",
+                        text: $passthroughText,
+                        missingHosts: passthroughOverrideMissingHosts,
+                        warningText: { joined in
+                            "This override would remove \(joined) from passthrough. Airlock would decrypt secrets in requests to Anthropic, sending your plaintext credentials to Anthropic's servers."
+                        }
+                    )
+                } else {
+                    Text(inheritedPassthroughDescription)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+```
+
+- [ ] **Step 3: Add `inheritedPassthroughDescription` computed property**
+
+Find the existing `inheritedAllowlistDescription` computed property (around lines 175–180). Add a new sibling property just above it:
+
+```swift
+    private var inheritedPassthroughDescription: String {
+        if globalSettings.passthroughHosts.isEmpty {
+            return "Inheriting global setting (no passthrough hosts — proxy decrypts all HTTPS)."
+        }
+        return "Inheriting global passthrough: \(globalSettings.passthroughHosts.joined(separator: ", "))."
+    }
+
+    private var inheritedAllowlistDescription: String {
+```
+
+- [ ] **Step 4: Change `passthroughOverrideMissingHosts` semantics**
+
+Find `private var passthroughOverrideMissingHosts: [String]` at lines 158–164. The current body is:
+
+```swift
+    /// Protected hosts missing from the workspace passthrough override.
+    /// Returns an empty list when the editor is empty (empty = inherit
+    /// global, not an explicit removal), so the HostListEditor only
+    /// shows the warning for explicit non-empty overrides.
+    private var passthroughOverrideMissingHosts: [String] {
+        let parsed = PassthroughPolicy.splitHostLines(passthroughText)
+        if parsed.isEmpty {
+            return []
+        }
+        return PassthroughPolicy.missingProtectedHosts(from: parsed)
+    }
+```
+
+Replace with:
+
+```swift
+    /// Protected hosts missing from the workspace passthrough override.
+    /// The override toggle gates this: when the toggle is OFF we return
+    /// an empty list (inherit is safe), but when ON we always check —
+    /// including the empty-editor case, which now means "explicitly no
+    /// passthrough for this workspace".
+    private var passthroughOverrideMissingHosts: [String] {
+        guard overridePassthrough else { return [] }
+        let parsed = PassthroughPolicy.splitHostLines(passthroughText)
+        return PassthroughPolicy.missingProtectedHosts(from: parsed)
+    }
+```
+
+- [ ] **Step 5: Update `load()` to initialize the toggle from the stored override**
+
+Find `private func load()` at lines 182–200. Replace the first three body lines after `globalSettings = ...`:
+
+```swift
+    private func load() {
+        globalSettings = (try? WorkspaceStore().loadSettings()) ?? AppSettings()
+        passthroughText = workspace.passthroughHostsOverride?.joined(separator: "\n") ?? ""
+        discoveredMCPServers = MCPInventoryService.discoverServerNames()
+```
+
+with:
+
+```swift
+    private func load() {
+        globalSettings = (try? WorkspaceStore().loadSettings()) ?? AppSettings()
+        if let override = workspace.passthroughHostsOverride {
+            overridePassthrough = true
+            passthroughText = override.joined(separator: "\n")
+        } else {
+            overridePassthrough = false
+            passthroughText = ""
+        }
+        discoveredMCPServers = MCPInventoryService.discoverServerNames()
+```
+
+- [ ] **Step 6: Update `save()` to gate the guardrail on the toggle**
+
+Find `private func save()` at lines 202–216:
+
+```swift
+    private func save() {
+        // Guardrails chain: passthrough → allow-list → commit. Each alert's
+        // "confirm anyway" button re-enters this chain via the next helper
+        // so users see BOTH warnings if they're both violated.
+        let hosts = PassthroughPolicy.splitHostLines(passthroughText)
+        // Empty override = inherit global; not flagged.
+        if !hosts.isEmpty {
+            let missing = PassthroughPolicy.missingProtectedHosts(from: hosts)
+            if !missing.isEmpty {
+                showRemoveAnthropicConfirm = true
+                return
+            }
+        }
+        proceedAfterPassthroughConfirmed()
+    }
+```
+
+Replace with:
+
+```swift
+    private func save() {
+        // Guardrails chain: passthrough → allow-list → commit. Each alert's
+        // "confirm anyway" button re-enters this chain via the next helper
+        // so users see BOTH warnings if they're both violated.
+        //
+        // The override toggle gates the passthrough guardrail: OFF = inherit
+        // global (safe, no check). ON = check the editor contents, including
+        // the empty-editor case which now means "explicitly no passthrough
+        // for this workspace".
+        if overridePassthrough {
+            let hosts = PassthroughPolicy.splitHostLines(passthroughText)
+            let missing = PassthroughPolicy.missingProtectedHosts(from: hosts)
+            if !missing.isEmpty {
+                showRemoveAnthropicConfirm = true
+                return
+            }
+        }
+        proceedAfterPassthroughConfirmed()
+    }
+```
+
+- [ ] **Step 7: Update `commitSave()` to branch on the toggle**
+
+Find `private func commitSave(hosts: [String])` at lines 229–243:
+
+```swift
+    private func commitSave(hosts: [String]) {
+        if let idx = appState.workspaces.firstIndex(where: { $0.id == workspace.id }) {
+            appState.workspaces[idx].passthroughHostsOverride = hosts.isEmpty ? nil : hosts
+            appState.workspaces[idx].enabledMCPServersOverride = overrideMCPServers
+                ? workspaceMCPSelection.sorted()
+                : nil
+            if overrideNetworkAllowlist {
+                appState.workspaces[idx].networkAllowlistOverride =
+                    NetworkAllowlistPolicy.splitHostLines(networkAllowlistText)
+            } else {
+                appState.workspaces[idx].networkAllowlistOverride = nil
+            }
+        }
+        try? WorkspaceStore().saveWorkspaces(appState.workspaces)
+    }
+```
+
+Replace the `passthroughHostsOverride` line with a toggle-based branch:
+
+```swift
+    private func commitSave(hosts: [String]) {
+        if let idx = appState.workspaces.firstIndex(where: { $0.id == workspace.id }) {
+            if overridePassthrough {
+                // Explicit override — empty array means "no passthrough for
+                // this workspace" (not "inherit"). nil is only written when
+                // the toggle is OFF.
+                appState.workspaces[idx].passthroughHostsOverride =
+                    PassthroughPolicy.splitHostLines(passthroughText)
+            } else {
+                appState.workspaces[idx].passthroughHostsOverride = nil
+            }
+            appState.workspaces[idx].enabledMCPServersOverride = overrideMCPServers
+                ? workspaceMCPSelection.sorted()
+                : nil
+            if overrideNetworkAllowlist {
+                appState.workspaces[idx].networkAllowlistOverride =
+                    NetworkAllowlistPolicy.splitHostLines(networkAllowlistText)
+            } else {
+                appState.workspaces[idx].networkAllowlistOverride = nil
+            }
+        }
+        try? WorkspaceStore().saveWorkspaces(appState.workspaces)
+    }
+```
+
+The `hosts` parameter is now unused in the passthrough branch. That is intentional — we read straight from `passthroughText` through `splitHostLines` so the explicit-empty case (`[]`) is preserved. All two callers of `commitSave` still pass a value; we leave the signature alone to avoid churning more code.
+
+- [ ] **Step 8: Build the GUI**
+
+Run: `make gui-build`
+
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 9: Run tests**
+
+Run: `make gui-test`
+
+Expected: All tests pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add AirlockApp/Sources/AirlockApp/Views/Settings/WorkspaceSettingsView.swift
+git commit -m "feat: add passthrough override toggle to workspace settings"
+```
+
+---
+
+## Task 4: Remove Secrets section from workspace settings
+
+**Files:**
+- Modify: `AirlockApp/Sources/AirlockApp/Views/Settings/WorkspaceSettingsView.swift:19-33`
+
+- [ ] **Step 1: Delete the Secrets section**
+
+Open `AirlockApp/Sources/AirlockApp/Views/Settings/WorkspaceSettingsView.swift`. Find and delete the entire `Section("Secrets") { ... }` block at lines 19–33:
+
+```swift
+            Section("Secrets") {
+                HStack {
+                    Text("Manage secret files in the Secrets tab (Cmd+2)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+                if let envPath = workspace.envFilePath {
+                    HStack {
+                        Text("Legacy .env: \((envPath as NSString).lastPathComponent)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+```
+
+After removal, `Form { ... }` should start directly with `Section("Container Overrides") { ... }`.
+
+- [ ] **Step 2: Build the GUI**
+
+Run: `make gui-build`
+
+Expected: Build succeeds.
+
+- [ ] **Step 3: Run tests**
+
+Run: `make gui-test`
+
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add AirlockApp/Sources/AirlockApp/Views/Settings/WorkspaceSettingsView.swift
+git commit -m "refactor: remove redundant Secrets section from workspace settings"
+```
+
+---
+
+## Task 5: Remove `.env file` field from New Workspace sheet
+
+**Files:**
+- Modify: `AirlockApp/Sources/AirlockApp/Views/Sidebar/NewWorkspaceSheet.swift`
+
+- [ ] **Step 1: Remove the `envFilePath` state property**
+
+In `AirlockApp/Sources/AirlockApp/Views/Sidebar/NewWorkspaceSheet.swift`, find lines 15–19:
+
+```swift
+    @State private var selectedPath: String = ""
+    @State private var envFilePath: String = ""
+    @State private var statusMessage: String = ""
+    @State private var isProcessing = false
+    @State private var checks: [PreCheck] = []
+```
+
+Delete the `envFilePath` line so the block reads:
+
+```swift
+    @State private var selectedPath: String = ""
+    @State private var statusMessage: String = ""
+    @State private var isProcessing = false
+    @State private var checks: [PreCheck] = []
+```
+
+- [ ] **Step 2: Remove the `.env file` HStack from the body**
+
+Find the HStack at lines 33–44:
+
+```swift
+            HStack {
+                TextField(".env file (optional)", text: $envFilePath)
+                    .textFieldStyle(.roundedBorder)
+                Button("Browse...") { pickEnvFile() }
+                if !envFilePath.isEmpty {
+                    Button { envFilePath = "" } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+```
+
+Delete the entire HStack block (including the trailing blank line).
+
+- [ ] **Step 3: Remove the `.onChange(of: envFilePath)` modifier**
+
+Find line 68:
+
+```swift
+        .onChange(of: selectedPath) { _, _ in Task { await runPreChecks() } }
+        .onChange(of: envFilePath) { _, _ in Task { await runPreChecks() } }
+```
+
+Delete the second line so only `selectedPath` has an onChange.
+
+- [ ] **Step 4: Remove the `.env` pre-check branch inside `runPreChecks()`**
+
+Find lines 127–147 inside `runPreChecks()`:
+
+```swift
+        if !envFilePath.isEmpty {
+            let envContent = (try? String(contentsOfFile: envFilePath, encoding: .utf8)) ?? ""
+            let sensitivePatterns = ["KEY", "SECRET", "PASSWORD", "TOKEN"]
+            let hasPlaintext = envContent
+                .components(separatedBy: .newlines)
+                .contains { line in
+                    let parts = line.split(separator: "=", maxSplits: 1)
+                    guard parts.count == 2 else { return false }
+                    let key = String(parts[0]).uppercased()
+                    let value = String(parts[1])
+                    return sensitivePatterns.contains(where: { key.contains($0) }) && !value.hasPrefix("ENC[age:")
+                }
+            if hasPlaintext {
+                results.append(PreCheck(
+                    id: "secrets",
+                    label: "Plaintext secrets detected",
+                    passed: false,
+                    detail: "will be encrypted on activation"
+                ))
+            }
+        }
+
+```
+
+Delete this entire block.
+
+- [ ] **Step 5: Remove `pickEnvFile()`**
+
+Find lines 174–182:
+
+```swift
+    private func pickEnvFile() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowsMultipleSelection = false
+        if panel.runModal() == .OK, let url = panel.url {
+            envFilePath = url.path
+        }
+    }
+
+```
+
+Delete this entire function.
+
+- [ ] **Step 6: Remove `envFilePath` argument from `Workspace(...)` init**
+
+Find the `addWorkspace()` function, specifically the `Workspace(...)` init around lines 203–207:
+
+```swift
+            let name = URL(filePath: path).lastPathComponent
+            let workspace = Workspace(
+                name: name,
+                path: path,
+                envFilePath: envFilePath.isEmpty ? nil : envFilePath
+            )
+```
+
+Replace with:
+
+```swift
+            let name = URL(filePath: path).lastPathComponent
+            let workspace = Workspace(
+                name: name,
+                path: path
+            )
+```
+
+`Workspace.init(name:path:envFilePath:containerImageOverride:)` already defaults `envFilePath` to `nil` (see `Workspace.swift:63`), so omitting it is safe.
+
+- [ ] **Step 7: Build the GUI**
+
+Run: `make gui-build`
+
+Expected: Build succeeds. No references to `envFilePath` should remain in `NewWorkspaceSheet.swift`. (They will still exist in `Workspace.swift`, `WorkspaceTests.swift`, and `ContainerSessionService.swift` — those are intentionally preserved for back-compat.)
+
+- [ ] **Step 8: Run tests**
+
+Run: `make gui-test`
+
+Expected: All tests pass. Existing `WorkspaceTests` testing `envFilePath` continue to pass because the model field is unchanged.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add AirlockApp/Sources/AirlockApp/Views/Sidebar/NewWorkspaceSheet.swift
+git commit -m "refactor: remove .env file field from New Workspace sheet"
+```
+
+---
+
+## Task 6: End-to-end manual smoke test
+
+**Files:** none (manual test only)
+
+- [ ] **Step 1: Launch the GUI**
+
+Run: `make gui-run`
+
+- [ ] **Step 2: Verify global settings section**
+
+1. Open global settings (Cmd+,).
+2. Find the section labeled **Passthrough Hosts** (not "Network Defaults").
+3. Confirm the `Enable passthrough hosts` toggle is ON and the editor shows current hosts (likely `api.anthropic.com`, `auth.anthropic.com`).
+4. Toggle OFF: the editor disappears and is replaced by the caption about plaintext credentials.
+5. Click Save. A confirm dialog should appear warning that Anthropic passthrough is being disabled.
+6. Click "Remove anyway". Dialog dismisses.
+7. Re-open global settings. Confirm toggle is OFF, editor is hidden.
+8. Toggle ON. The editor reappears with the previously entered hosts (restored from `passthroughHostsDraft`).
+9. Click Save (no dialog since the hosts are restored).
+
+- [ ] **Step 3: Verify workspace settings section**
+
+1. Select a workspace in the sidebar.
+2. Open the Settings tab (Cmd+4).
+3. Confirm there is NO `Secrets` section.
+4. Find the section labeled **Passthrough Override** (not "Network Overrides").
+5. Confirm the `Override global passthrough` toggle is OFF and the caption reads "Inheriting global passthrough: ...".
+6. Toggle ON. The editor appears prefilled with the global passthrough hosts.
+7. Clear the editor. Click Save. A confirm dialog fires warning that the workspace blocks Anthropic (new semantic: empty + ON = explicit block).
+8. Click Cancel. Toggle off. Click Save — no dialog (inherit is safe).
+
+- [ ] **Step 4: Verify New Workspace sheet**
+
+1. Click the `+` button in the sidebar.
+2. Confirm there is NO `.env file (optional)` TextField.
+3. Confirm there is NO `Plaintext secrets detected` pre-check row (even when selecting a directory that contains a `.env` file).
+4. Select a project directory and create the workspace. It should appear in the sidebar with no errors.
+
+- [ ] **Step 5: Verify existing workspace with `envFilePath` (if available)**
+
+If you have an existing workspace in `~/Library/Application Support/airlock/workspaces.json` with an `envFilePath` value set:
+
+1. Activate it — it should still start the container with the `--env` flag passed through by `ContainerSessionService`.
+2. Open its Settings tab — the Secrets section is gone (so the legacy `.env` path is no longer shown in the UI), but activation continues to work.
+
+If no such workspace exists, skip this step.
+
+- [ ] **Step 6: Mark the manual test as complete**
+
+There is nothing to commit. Notify the user that the manual smoke test passed.
+
+---
+
+## Self-Review Results
+
+**Spec coverage:**
+- Item 1 (rename + toggle global): Task 2 ✅
+- Item 2 (rename + toggle workspace): Task 3 ✅
+- Item 3 (remove `.env` from New Workspace sheet + precheck row): Task 5 ✅
+- Item 4 (remove Secrets section from workspace settings): Task 4 ✅
+- `AppSettings.passthroughHostsDraft` field: Task 1 ✅
+- Draft round-trip tests: Task 1 ✅
+- Manual verification: Task 6 ✅
+
+**Placeholder scan:** No TBD/TODO. Every code step shows the concrete before/after. All commit messages are concrete. `PassthroughPolicy.splitHostLines` and `PassthroughPolicy.missingProtectedHosts` are the existing helpers used throughout the repo and require no new code.
+
+**Type consistency:** `passthroughHostsDraft: [String]?` is used consistently in Tasks 1, 2, and verified in the round-trip test. `overridePassthrough: Bool`, `enablePassthrough: Bool`, and `inheritedPassthroughDescription` are each referenced exactly where declared. The `passthroughHostsOverride: [String]?` field on `Workspace` is unchanged at the model level — only the write path changes in Task 3.

--- a/docs/superpowers/specs/2026-04-09-gui-minor-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-09-gui-minor-fixes-design.md
@@ -1,0 +1,171 @@
+# GUI Minor Fixes Design
+
+**Date:** 2026-04-09
+**Branch:** `feat/gui-minor-fixes`
+**Status:** Approved
+
+## Summary
+
+Four small GUI adjustments in the SwiftUI app to reduce confusion between "Network Defaults/Overrides" (passthrough) and "Network Allow-list", and to retire the `.env file` flow from the New Workspace sheet now that env secrets have moved into the Secrets tab.
+
+## Motivation
+
+- "Network Defaults" and "Network Overrides" are visually adjacent to "Network Allow-list" but mean a completely different thing (which hosts skip the proxy decrypt pass). Users conflate them.
+- The passthrough sections are the only network-area sections without an explicit on/off toggle, breaking consistency with MCP Servers and Network Allow-list.
+- The New Workspace sheet still offers a `.env file (optional)` field that predates `airlock secret env add` and the Secrets tab. It is the only place in the GUI that still introduces a legacy `envFilePath` flow to new users.
+- The workspace settings "Secrets" section is a pointer to the Secrets tab plus a legacy-path display. Both are clutter.
+
+## Scope
+
+### Item 1 — Global Settings: `Passthrough Hosts` section
+
+Target: `AirlockApp/Sources/AirlockApp/Views/Settings/SettingsView.swift`
+
+- Rename `Section("Network Defaults")` → `Section("Passthrough Hosts")`.
+- Add a toggle `Toggle("Enable passthrough hosts", isOn: $enablePassthrough)`.
+- Toggle ON: show the existing `HostListEditor` unchanged.
+- Toggle OFF: show a caption — "All outbound HTTPS, including Anthropic, will flow through the proxy for secret decryption. Your plaintext credentials will be sent to Anthropic's servers."
+- Save semantics:
+  - Toggle ON: `settings.passthroughHosts = [parsed hosts]`
+  - Toggle OFF: `settings.passthroughHosts = []`
+- Guardrail: no change. `PassthroughPolicy.missingProtectedHosts([])` already triggers `showRemoveAnthropicConfirm` on save.
+
+### Item 2 — Workspace Settings: `Passthrough Override` section
+
+Target: `AirlockApp/Sources/AirlockApp/Views/Settings/WorkspaceSettingsView.swift`
+
+- Rename `Section("Network Overrides")` → `Section("Passthrough Override")`.
+- Add a toggle `Toggle("Override global passthrough", isOn: $overridePassthrough)`.
+- Toggle OFF: caption — "Inheriting global passthrough: `<hosts>`" or "Inheriting global setting (no passthrough hosts)." (mirrors `inheritedAllowlistDescription`).
+- Toggle ON: show the existing `HostListEditor`.
+- On OFF → ON transition: prefill editor with `globalSettings.passthroughHosts` (mirrors the network allow-list override pattern at `WorkspaceSettingsView.swift:88`).
+- Save semantics (meaning change approved by user):
+  - Toggle OFF → `workspace.passthroughHostsOverride = nil` (inherit)
+  - Toggle ON + any content (including empty editor) → `workspace.passthroughHostsOverride = [parsed hosts]` (possibly an empty array, explicit "no passthrough" for this workspace)
+- Guardrail: fire `showRemoveAnthropicConfirm` whenever the toggle is ON and `PassthroughPolicy.missingProtectedHosts(parsed)` is non-empty — this now includes the empty-editor case, which previously was silently treated as inherit.
+- Update `passthroughOverrideMissingHosts` computed property: remove the early-return on `parsed.isEmpty`. That early-return was the old "empty = inherit" shortcut.
+
+### Item 3 — New Workspace sheet: remove `.env` flow
+
+Target: `AirlockApp/Sources/AirlockApp/Views/Sidebar/NewWorkspaceSheet.swift`
+
+Remove:
+- `@State private var envFilePath: String = ""`
+- The `.env file (optional)` `TextField` + Browse button + clear button HStack (lines 33–44)
+- `.onChange(of: envFilePath)` modifier (line 68)
+- The `if !envFilePath.isEmpty { ... }` block inside `runPreChecks()` that emits the `"Plaintext secrets detected"` PreCheck (lines 127–147)
+- `pickEnvFile()` function
+- `envFilePath` argument in the `Workspace(...)` init inside `addWorkspace()` (defaults to `nil`)
+
+### Item 4 — Workspace Settings: remove `Secrets` section
+
+Target: `AirlockApp/Sources/AirlockApp/Views/Settings/WorkspaceSettingsView.swift`
+
+- Delete the `Section("Secrets") { ... }` block (lines 19–33). It contains the caption "Manage secret files in the Secrets tab (Cmd+2)" and the conditional `if let envPath = workspace.envFilePath` row.
+
+## Data Model Impact
+
+### `AppSettings` — add `passthroughHostsDraft`
+
+Add `passthroughHostsDraft: [String]?` on `AppSettings`, persisted in `settings.json`. The CLI layer never reads it. Only `SettingsView.load()` and `SettingsView.commitSave()` touch it. Purpose: preserve the editor text when the global passthrough toggle is OFF, across app restarts (the user's explicit A1-on-setting-file requirement).
+
+- Field: `var passthroughHostsDraft: [String]?` on `AppSettings`
+- Codable: `decodeIfPresent`, default `nil`
+- Write path: `commitSave()` sets `passthroughHostsDraft` to current editor lines when toggle is OFF, and to `nil` when toggle is ON.
+- Read path: `load()` — if `passthroughHosts` is non-empty, use it; else fall back to `passthroughHostsDraft ?? []`.
+- Tests: add a round-trip test in `AppStateTests.swift` (or wherever `AppSettings` coding is tested) that saves a `draft` with empty `passthroughHosts` and verifies it decodes.
+
+### `Workspace.envFilePath` — preserved
+
+`Workspace.envFilePath: String?` stays. Keeping it means:
+- Existing workspaces with `envFilePath` set keep activating with `--env <path>` via `ContainerSessionService.activate()` at `ContainerSessionService.swift:24`.
+- `WorkspaceTests.swift` continues to pass.
+- Newly created workspaces always have `envFilePath = nil` because the field is removed from `NewWorkspaceSheet`.
+
+### `Workspace.passthroughHostsOverride` — semantic change, no model change
+
+The field is already `[String]?` with `decodeIfPresent`, so nil vs empty array are distinguishable at the JSON level. The old UI collapsed empty to nil on save. The new UI preserves the distinction.
+
+## Architecture / Behavior
+
+### Guardrail chains
+
+Global (`SettingsView.save` → `proceedAfterPassthroughConfirmed` → `commitSave`):
+- Unchanged. Toggle OFF just writes `passthroughHosts = []`, which is the same input the existing chain already handles (empty array → missing protected hosts → confirm alert).
+
+Workspace (`WorkspaceSettingsView.save` → `proceedAfterPassthroughConfirmed` → `commitSave`):
+- The `if !hosts.isEmpty` guard in `save()` must be replaced. New condition: `if overridePassthrough { check missingProtectedHosts }`. When the toggle is OFF, skip the passthrough guardrail (inherit is safe).
+- `commitSave`: branch on `overridePassthrough`, not on `hosts.isEmpty`.
+
+### State restoration
+
+`SettingsView.load()`:
+```
+if settings.passthroughHosts.isEmpty && settings.passthroughHostsDraft == nil {
+    enablePassthrough = false
+    passthroughText = ""
+} else if settings.passthroughHosts.isEmpty {
+    enablePassthrough = false
+    passthroughText = draft.joined("\n")
+} else {
+    enablePassthrough = true
+    passthroughText = settings.passthroughHosts.joined("\n")
+}
+```
+
+`WorkspaceSettingsView.load()`:
+```
+if let override = workspace.passthroughHostsOverride {
+    overridePassthrough = true
+    passthroughText = override.joined("\n")
+} else {
+    overridePassthrough = false
+    passthroughText = ""  // not prefilled until the toggle flips ON
+}
+```
+
+`WorkspaceSettingsView` on toggle change:
+```
+.onChange(of: overridePassthrough) { _, newValue in
+    if !newValue {
+        // Leave passthroughText alone in memory so user can flip back without losing work.
+    } else if passthroughText.isEmpty {
+        passthroughText = globalSettings.passthroughHosts.joined("\n")
+    }
+}
+```
+
+## Testing Plan
+
+### Unit
+
+- `AppSettings` round-trip: new `passthroughHostsDraft` field decodes with legacy JSON (missing key → nil). Saves non-empty draft with empty hosts.
+- `Workspace` model tests: unchanged, continue to pass (envFilePath field still present).
+
+### Manual
+
+1. **Global toggle OFF → Save**: expect `showRemoveAnthropicConfirm`. Confirm → `settings.json` has `passthroughHosts: []` and `passthroughHostsDraft: [...]`.
+2. **Global toggle OFF, close & reopen app**: editor shows preserved draft, toggle is OFF.
+3. **Global toggle ON, Anthropic-free hosts, Save**: same confirm alert, same behavior as today.
+4. **Workspace toggle OFF**: caption shows inherited hosts. Save → no alert, `passthroughHostsOverride = nil` in workspaces.json.
+5. **Workspace toggle OFF → ON**: editor prefilled with global hosts.
+6. **Workspace toggle ON + clear editor → Save**: confirm alert fires (new semantic). Confirm → `passthroughHostsOverride = []`.
+7. **New Workspace sheet**: no `.env` field. Create a workspace, open workspace settings — no Secrets section visible.
+8. **Existing workspace with legacy `envFilePath`**: still activates correctly (CLI still gets `--env`). No UI exposes the legacy path.
+
+## Out of Scope
+
+- Removing `Workspace.envFilePath` field or `--env` CLI flag.
+- Migrating existing workspaces with `envFilePath` set.
+- Changing `SecretsView.passthroughBanner`.
+- Changing `Section("Network Allow-list")` or `Section("MCP Servers")` in either view.
+- Any Go/Python changes.
+
+## References
+
+- `AirlockApp/Sources/AirlockApp/Views/Settings/SettingsView.swift:70-81` — current Network Defaults section
+- `AirlockApp/Sources/AirlockApp/Views/Settings/WorkspaceSettingsView.swift:50-62` — current Network Overrides section
+- `AirlockApp/Sources/AirlockApp/Views/Settings/WorkspaceSettingsView.swift:19-33` — current Secrets section
+- `AirlockApp/Sources/AirlockApp/Views/Sidebar/NewWorkspaceSheet.swift:33-44, 127-147` — current `.env` field and precheck
+- `AirlockApp/Sources/AirlockApp/Models/Workspace.swift:7` — `envFilePath` field (preserved)
+- `AirlockApp/Sources/AirlockApp/Services/ContainerSessionService.swift:24-26` — `--env` CLI flag passthrough (preserved)


### PR DESCRIPTION
## Summary

Four GUI adjustments to reduce confusion between the passthrough sections and the network allow-list, and to retire the legacy `.env file` flow from the New Workspace sheet.

- **Global Settings**: rename `Network Defaults` → `Passthrough Hosts` + add on/off toggle. Toggle OFF preserves editor text across app restarts via new `AppSettings.passthroughHostsDraft` field.
- **Workspace Settings**: rename `Network Overrides` → `Passthrough Override` + add override toggle. OFF→ON transition prefills from global. Semantic change: `passthroughHostsOverride = nil` means inherit global, `[]` means explicit "no passthrough for this workspace" (previously `[]` was collapsed to `nil` on save).
- **New Workspace sheet**: remove the `.env file` field, picker, and `Plaintext secrets detected` precheck. Env secrets now live exclusively in the Secrets tab.
- **Workspace Settings**: remove the redundant `Secrets` section (it only pointed users to the Secrets tab + displayed a legacy `.env` row).

`Workspace.envFilePath` model field and `--env` CLI plumbing are intentionally preserved for back-compat with existing workspaces.

## Test plan

- [x] `make gui-test` passes (82/82, includes 4 new tests)
- [x] Manual E2E smoke test — all scenarios pass
- [x] Global toggle OFF → Save → reopen → editor text restored from draft
- [x] Workspace toggle OFF→ON → editor prefilled with global
- [x] Workspace toggle ON + empty editor → guardrail alert fires (new semantic)
- [x] New Workspace sheet has no `.env` field and no secrets precheck
- [x] Workspace settings has no `Secrets` section
- [x] Legacy workspaces with `envFilePath` still activate via `--env` CLI flag
- [x] All four `Review-fix-simplify` rounds clean (see commit history for issue/fix trail)

## Notes

- Documentation synchronized: `docs/guides/security-model.md`, `docs/decisions/ADR-0010-environment-variable-secrets.md`, and both manual test runbooks (`docs/superpowers/plans/2026-04-0{7,8}-*.md`) updated for new section names and toggle semantics.
- DRY cleanup: both `SettingsView.commitSave()` and `WorkspaceSettingsView.commitSave()` take no parameters; guardrail checks and alert messages share one source of truth via computed properties.